### PR TITLE
Beam MC Information

### DIFF
--- a/larpandora/LArPandoraInterface/CMakeLists.txt
+++ b/larpandora/LArPandoraInterface/CMakeLists.txt
@@ -6,6 +6,7 @@ art_make(
           LIB_LIBRARIES larcorealg_Geometry
                         larcore_Geometry_Geometry_service
                         larsim_Simulation lardataobj_Simulation
+                        larsim_MCCheater_BackTracker_service 
                         lardataobj_RawData
                         lardataobj_RecoBase
                         lardataobj_AnalysisBase


### PR DESCRIPTION
This branch has now been rebased from the LArRemaster branch instead of the master branch and a new pull request created.  Initial comment on previous pull request: 

"Set the nuance code for non-neutrino MC particles to determine whether the particle originates from beam or cosmic ray.

This information will be needed for developing the beamID. It may be worth adding an enumerated type in Pandora for the beam and cosmic ray information as is done for the neutrino interaction type, although this can wait for a later date if needed."
