### PR TITLE
Triggered MC Info

### DIFF
--- a/larpandora/LArPandoraInterface/LArPandora.h
+++ b/larpandora/LArPandoraInterface/LArPandora.h
@@ -51,6 +51,7 @@ private:
     void CreatePandoraInput(art::Event &evt, IdToHitMap &idToHitMap);
     void ProcessPandoraOutput(art::Event &evt, const IdToHitMap &idToHitMap);
 
+    std::string                     m_generatorModuleLabel;         ///< The generator module label
     std::string                     m_geantModuleLabel;             ///< The geant module label
     std::string                     m_hitfinderModuleLabel;         ///< The hit finder module label
 

--- a/larpandora/LArPandoraInterface/LArPandoraHelper.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraHelper.cxx
@@ -715,7 +715,7 @@ void LArPandoraHelper::CollectMCParticles(const art::Event &evt, const std::stri
     if (evt.isRealData())
         throw cet::exception("LArPandora") << " PandoraCollector::CollectMCParticles --- Trying to access MC truth from real data ";
 
-    art::Handle< std::vector<simb::MCParticle> > theParticles;
+    art::Handle< RawMCParticleVector > theParticles;
     evt.getByLabel(label, theParticles);
 
     if (!theParticles.isValid())
@@ -737,13 +737,45 @@ void LArPandoraHelper::CollectMCParticles(const art::Event &evt, const std::stri
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
+void LArPandoraHelper::CollectGeneratorMCParticles(const art::Event &evt, const std::string &label, RawMCParticleVector &particleVector)
+{
+    if (evt.isRealData())
+        throw cet::exception("LArPandora") << " PandoraCollector::CollectGeneratorMCParticles --- Trying to access MC truth from real data ";
+
+    art::Handle< std::vector<simb::MCTruth> > mcTruthBlocks;
+    evt.getByLabel(label, mcTruthBlocks);
+
+    if (!mcTruthBlocks.isValid())
+    {
+        mf::LogDebug("LArPandora") << "  Failed to find MC truth blocks from generator... " << std::endl;
+        return;
+    }
+    else
+    {
+        mf::LogDebug("LArPandora") << "  Found: " << mcTruthBlocks->size() << " MC truth blocks " << std::endl;
+    }
+
+    if (mcTruthBlocks->size() != 1)
+        throw cet::exception("LArPandora") << " PandoraCollector::CollectGeneratorMCParticles --- Unexpected number of MC truth blocks ";
+
+    const art::Ptr<simb::MCTruth> mcTruth(mcTruthBlocks, 0);
+
+    for (int i = 0; i < mcTruth->NParticles(); ++i)
+    {
+        particleVector.push_back(mcTruth->GetParticle(i));
+    }
+}
+
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
 void LArPandoraHelper::CollectMCParticles(const art::Event &evt, const std::string &label, MCTruthToMCParticles &truthToParticles,
     MCParticlesToMCTruth &particlesToTruth)
 {
     if (evt.isRealData())
         throw cet::exception("LArPandora") << " PandoraCollector::CollectMCParticles --- Trying to access MC truth from real data ";
 
-    art::Handle< std::vector<simb::MCParticle> > theParticles;
+    art::Handle< RawMCParticleVector > theParticles;
     evt.getByLabel(label, theParticles);
 
     if (!theParticles.isValid())

--- a/larpandora/LArPandoraInterface/LArPandoraHelper.h
+++ b/larpandora/LArPandoraInterface/LArPandoraHelper.h
@@ -39,6 +39,7 @@ typedef std::vector< art::Ptr<recob::Shower> >      ShowerVector;
 typedef std::vector< art::Ptr<recob::PFParticle> >  PFParticleVector;
 typedef std::vector< art::Ptr<simb::MCTruth> >      MCTruthVector;
 typedef std::vector< art::Ptr<simb::MCParticle> >   MCParticleVector;
+typedef std::vector< simb::MCParticle>              RawMCParticleVector;
 typedef std::vector< art::Ptr<sim::SimChannel> >    SimChannelVector;
 typedef std::vector< sim::TrackIDE >                TrackIDEVector;
 typedef std::vector< art::Ptr<anab::CosmicTag> >    CosmicTagVector;
@@ -353,6 +354,16 @@ public:
      *  @param particleVector the output vector of MCParticle objects
      */
     static void CollectMCParticles(const art::Event &evt, const std::string &label, MCParticleVector &particleVector);
+
+    /**
+     *  @brief Collect a vector of MCParticle objects from the generator in the ART event record.  ATTN: This function is 
+     *         needed as accessing generator (opposed to Geant4) level MCParticles requires use of MCTruth block.
+     *
+     *  @param evt the ART event record
+     *  @param label the label for the truth information in the generator
+     *  @param particleVector the output vector of MCParticle objects
+     */
+    static void CollectGeneratorMCParticles(const art::Event &evt, const std::string &label, RawMCParticleVector &particleVector);
 
     /**
      *  @brief Collect truth information from the ART event record

--- a/larpandora/LArPandoraInterface/LArPandoraInput.h
+++ b/larpandora/LArPandoraInterface/LArPandoraInput.h
@@ -89,7 +89,23 @@ public:
      *  @param  particlesToTruth  mapping from MC particles to MC truth
      */
     static void CreatePandoraMCParticles(const Settings &settings, const MCTruthToMCParticles &truthToParticles,
-        const MCParticlesToMCTruth &particlesToTruth);
+        const MCParticlesToMCTruth &particlesToTruth, const RawMCParticleVector &generatorMCParticleVector);
+
+    /**
+     *  @brief Find all primary MCParticles in a given vector of MCParticles
+     *
+     *  @param mcParticleVector vector of all MCParticles to consider
+     *  @param primaryMCParticleMap map containing primary MCParticles and bool indicating whether particle has been accounted for
+     */
+    static void FindPrimaryParticles(const RawMCParticleVector &mcParticleVector, std::map<const simb::MCParticle, bool> &primaryMCParticleMap);
+
+    /**
+     *  @brief Check whether an MCParticle can be found in a given map
+     *
+     *  @param mcParticle target MCParticle
+     *  @param primaryMCParticleMap map containing primary MCParticles and bool indicating whether particle has been accounted for
+     */
+    static bool IsPrimaryMCParticle(const art::Ptr<simb::MCParticle> &mcParticle, std::map<const simb::MCParticle, bool> &primaryMCParticleMap);
 
     /**
      *  @brief  Create links between the 2D hits and Pandora MC particles


### PR DESCRIPTION
Access the MCTruth block produced by the generator to determine, which particles (non-neutrino) are primary (i.e. triggered beam particles for ProtoDUNE).