### PR TITLE
fixing the order of hits associations with metadata, adding order fro…

### DIFF
--- a/larpandora/LArPandoraEventBuilding/LArPandoraTrackCreation_module.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraTrackCreation_module.cc
@@ -208,15 +208,21 @@ void LArPandoraTrackCreation::produce(art::Event &evt)
         }
 
         HitVector hitsFromSpacePoints, hitsFromClusters, hitsInParticle;
+        HitSet hitsInParticleSet;
+
         LArPandoraHelper::GetAssociatedHits(evt, m_pfParticleLabel, particleToSpacePointIter->second, hitsFromSpacePoints, &indexVector);
         LArPandoraHelper::GetAssociatedHits(evt, m_pfParticleLabel, particleToClustersIter->second, hitsFromClusters);
         //ATTN: we want the order of hits from space points if they made them, to match trajectory points,
         //but we also want as many hits as clustered, so add the ones not associated to space points at the end
         for (unsigned int hitIndex = 0; hitIndex < hitsFromSpacePoints.size(); hitIndex++)
+        {
 	    hitsInParticle.push_back(hitsFromSpacePoints.at(hitIndex));
+            hitsInParticleSet.insert(hitsFromSpacePoints.at(hitIndex));
+        }
+
         for (unsigned int hitIndex = 0; hitIndex < hitsFromClusters.size(); hitIndex++)
         {
-            if (std::find(hitsInParticle.begin(), hitsInParticle.end(), hitsFromClusters.at(hitIndex)) == hitsInParticle.end())
+            if (hitsInParticleSet.count(hitsFromClusters.at(hitIndex)) == 0)
                 hitsInParticle.push_back(hitsFromClusters.at(hitIndex));
         }
 

--- a/larpandora/LArPandoraEventBuilding/LArPandoraTrackCreation_module.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraTrackCreation_module.cc
@@ -212,8 +212,7 @@ void LArPandoraTrackCreation::produce(art::Event &evt)
 
         LArPandoraHelper::GetAssociatedHits(evt, m_pfParticleLabel, particleToSpacePointIter->second, hitsFromSpacePoints, &indexVector);
         LArPandoraHelper::GetAssociatedHits(evt, m_pfParticleLabel, particleToClustersIter->second, hitsFromClusters);
-        //ATTN: we want the order of hits from space points if they made them, to match trajectory points,
-        //but we also want as many hits as clustered, so add the ones not associated to space points at the end
+        //ATTN: hits ordered from space points if available, rest added at the end
         for (unsigned int hitIndex = 0; hitIndex < hitsFromSpacePoints.size(); hitIndex++)
         {
 	    hitsInParticle.push_back(hitsFromSpacePoints.at(hitIndex));
@@ -245,7 +244,7 @@ void LArPandoraTrackCreation::produce(art::Event &evt)
         util::CreateAssn(*this, evt, pTrack, pPFParticle, *(outputParticlesToTracks.get()));
         util::CreateAssn(*this, evt, *(outputTracks.get()), hitsInParticle, *(outputTracksToHits.get()));
 
-	//ATTN: now adding metadata to those with an index from space points only, for the rest should be null
+	//ATTN: metadata added with index from space points if available, null for others
         for (unsigned int hitIndex = 0; hitIndex < hitsInParticle.size(); hitIndex++)
         {
             const art::Ptr<recob::Hit> pHit(hitsInParticle.at(hitIndex));

--- a/larpandora/LArPandoraEventBuilding/LArPandoraTrackCreation_module.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraTrackCreation_module.cc
@@ -216,7 +216,7 @@ void LArPandoraTrackCreation::produce(art::Event &evt)
         for (unsigned int hitIndex = 0; hitIndex < hitsFromSpacePoints.size(); hitIndex++)
         {
 	    hitsInParticle.push_back(hitsFromSpacePoints.at(hitIndex));
-            hitsInParticleSet.insert(hitsFromSpacePoints.at(hitIndex));
+            (void) hitsInParticleSet.insert(hitsFromSpacePoints.at(hitIndex));
         }
 
         for (unsigned int hitIndex = 0; hitIndex < hitsFromClusters.size(); hitIndex++)

--- a/larpandora/LArPandoraInterface/LArPandoraHelper.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraHelper.cxx
@@ -1064,7 +1064,7 @@ void LArPandoraHelper::GetAssociatedHits(const art::Event &evt, const std::strin
     evt.getByLabel(label, handle);
     art::FindManyP<recob::Hit> hitAssoc(handle, evt, label);
 
-    if (indexVector != nullptr)
+    if ((indexVector != nullptr) && (inputVector.size()==indexVector->size()))
     {
         // If indexVector is filled, sort hits according to trajectory points order
         for (int index : (*indexVector))

--- a/larpandora/LArPandoraInterface/LArPandoraHelper.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraHelper.cxx
@@ -1064,8 +1064,11 @@ void LArPandoraHelper::GetAssociatedHits(const art::Event &evt, const std::strin
     evt.getByLabel(label, handle);
     art::FindManyP<recob::Hit> hitAssoc(handle, evt, label);
 
-    if ((indexVector != nullptr) && (inputVector.size()==indexVector->size()))
+    if (indexVector != nullptr)
     {
+        if (inputVector.size() != indexVector->size())
+            throw cet::exception("LArPandora") << " PandoraHelper::GetAssociatedHits --- trying to use an index vector not matching input vector";
+
         // If indexVector is filled, sort hits according to trajectory points order
         for (int index : (*indexVector))
         {
@@ -1073,7 +1076,9 @@ void LArPandoraHelper::GetAssociatedHits(const art::Event &evt, const std::strin
             const HitVector &hits = hitAssoc.at(element.key());
             associatedHits.insert(associatedHits.end(), hits.begin(), hits.end());
         }
-    } else {
+    }
+    else
+    {
         // If indexVector is empty just loop through inputSpacePoints
         for (const art::Ptr<T> &element : inputVector)
         {

--- a/larpandora/LArPandoraInterface/LArPandoraHelper.h
+++ b/larpandora/LArPandoraInterface/LArPandoraHelper.h
@@ -47,6 +47,8 @@ typedef std::vector< art::Ptr<anab::CosmicTag> >    CosmicTagVector;
 typedef std::vector< art::Ptr<anab::T0> >           T0Vector;
 typedef std::vector< art::Ptr<larpandoraobj::PFParticleMetadata> >  MetadataVector;
 
+typedef std::unordered_set< art::Ptr<recob::Hit> > HitSet;
+
 typedef std::map< art::Ptr<recob::PFParticle>, TrackVector >                  PFParticlesToTracks;
 typedef std::map< art::Ptr<recob::PFParticle>, ShowerVector >                 PFParticlesToShowers;
 typedef std::map< art::Ptr<recob::PFParticle>, ClusterVector >                PFParticlesToClusters;

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -7,7 +7,7 @@ fcldir  product_dir job
 fwdir   product_dir scripts
 #
 product         version
-larreco         v07_04_01
+larreco         v07_03_01
 larpandoracontent         v03_14_01
 
 cetbuildtools	v7_04_00	-	only_for_build

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -7,7 +7,7 @@ fcldir  product_dir job
 fwdir   product_dir scripts
 #
 product         version
-larreco         v07_03_01
+larreco         v07_04_01
 larpandoracontent         v03_14_01
 
 cetbuildtools	v7_04_00	-	only_for_build


### PR DESCRIPTION
Fixing the order of hits associations with metadata, adding order from spacepoints in trajectory if available, rest (from clusters) at the end, with a metadata index set to numeric_limits<int>::max - this is for calorimetry analyses. Notice also the Helper update needed as it doesn't make sense to be used in the case of clusters (if by mistake we passed a indexVector) 