### PR TITLE
Added a check for when SimChannels object is available, but empty

### DIFF
--- a/larpandora/LArPandoraInterface/LArPandora.cxx
+++ b/larpandora/LArPandoraInterface/LArPandora.cxx
@@ -175,7 +175,7 @@ void LArPandora::CreatePandoraInput(art::Event &evt, IdToHitMap &idToHitMap)
     MCTruthToMCParticles artMCTruthToMCParticles;
     MCParticlesToMCTruth artMCParticlesToMCTruth;
 
-    bool validSimChannels(false);
+    bool areSimChannelsValid(false);
 
     LArPandoraHelper::CollectHits(evt, m_hitfinderModuleLabel, artHits);
 
@@ -188,25 +188,22 @@ void LArPandora::CreatePandoraInput(art::Event &evt, IdToHitMap &idToHitMap)
 
         LArPandoraHelper::CollectMCParticles(evt, m_geantModuleLabel, artMCTruthToMCParticles, artMCParticlesToMCTruth);
 
-	LArPandoraHelper::CollectSimChannels(evt, m_geantModuleLabel, artSimChannels, validSimChannels);
+        LArPandoraHelper::CollectSimChannels(evt, m_simChannelModuleLabel, artSimChannels, areSimChannelsValid);
         if (!artSimChannels.empty())
         {
             LArPandoraHelper::BuildMCParticleHitMaps(artHits, artSimChannels, artHitsToTrackIDEs);
         }
-        else
+        else if (!areSimChannelsValid)
         {
-	    if (!validSimChannels)
-	    {
-              if (m_backtrackerModuleLabel.empty())
+            if (m_backtrackerModuleLabel.empty())
 	        throw cet::exception("LArPandora") << "LArPandora::CreatePandoraInput - Can't build MCParticle to Hit map." << std::endl <<
                     "No SimChannels found with label \"" << m_simChannelModuleLabel << "\", and BackTrackerModuleLabel isn't set in FHiCL." << std::endl;
-  
-              LArPandoraHelper::BuildMCParticleHitMaps(evt, m_hitfinderModuleLabel, m_backtrackerModuleLabel, artHitsToTrackIDEs);         
-	    }
-            else
-	    {
-	      mf::LogDebug("LArPandora") << " *** LArPandora::CreatePandoraInput - empty list of sim channels found " << std::endl;
-            }
+
+            LArPandoraHelper::BuildMCParticleHitMaps(evt, m_hitfinderModuleLabel, m_backtrackerModuleLabel, artHitsToTrackIDEs);
+        }
+        else
+        {
+	    mf::LogDebug("LArPandora") << " *** LArPandora::CreatePandoraInput - empty list of sim channels found " << std::endl;
         }
     }
 
@@ -227,7 +224,7 @@ void LArPandora::ProcessPandoraOutput(art::Event &evt, const IdToHitMap &idToHit
     {
         m_outputSettings.m_shouldProduceAllOutcomes = false;
         LArPandoraOutput::ProduceArtOutput(m_outputSettings, idToHitMap, evt);
-        
+
         if (m_shouldProduceAllOutcomes)
         {
             m_outputSettings.m_shouldProduceAllOutcomes = true;

--- a/larpandora/LArPandoraInterface/LArPandoraHelper.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraHelper.cxx
@@ -735,7 +735,7 @@ void LArPandoraHelper::CollectT0s(const art::Event &evt, const std::string &labe
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArPandoraHelper::CollectSimChannels(const art::Event &evt, const std::string &label, SimChannelVector &simChannelVector)
+void LArPandoraHelper::CollectSimChannels(const art::Event &evt, const std::string &label, SimChannelVector &simChannelVector, bool &isValid)
 {
     if (evt.isRealData())
         throw cet::exception("LArPandora") << " PandoraCollector::CollectSimChannels --- Trying to access MC truth from real data ";
@@ -746,11 +746,13 @@ void LArPandoraHelper::CollectSimChannels(const art::Event &evt, const std::stri
     if (!theSimChannels.isValid())
     {
         mf::LogDebug("LArPandora") << "  Failed to find sim channels... " << std::endl;
+        isValid = false;
         return;
     }
     else
     {
         mf::LogDebug("LArPandora") << "  Found: " << theSimChannels->size() << " SimChannels " << std::endl;
+        isValid = true;
     }
 
     for (unsigned int i = 0; i < theSimChannels->size(); ++i)
@@ -976,7 +978,9 @@ void LArPandoraHelper::BuildMCParticleHitMaps(const art::Event &evt, const std::
     MCParticlesToMCTruth particlesToTruth;
     HitsToTrackIDEs hitsToTrackIDEs;
 
-    LArPandoraHelper::CollectSimChannels(evt, label, simChannelVector);
+    bool validSimChannels;
+    LArPandoraHelper::CollectSimChannels(evt, label, simChannelVector, validSimChannels);
+
     LArPandoraHelper::CollectMCParticles(evt, label, truthToParticles, particlesToTruth);
     LArPandoraHelper::BuildMCParticleHitMaps(hitVector, simChannelVector, hitsToTrackIDEs);
     LArPandoraHelper::BuildMCParticleHitMaps(hitsToTrackIDEs, truthToParticles, particlesToHits, hitsToParticles, daughterMode);

--- a/larpandora/LArPandoraInterface/LArPandoraHelper.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraHelper.cxx
@@ -735,7 +735,7 @@ void LArPandoraHelper::CollectT0s(const art::Event &evt, const std::string &labe
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArPandoraHelper::CollectSimChannels(const art::Event &evt, const std::string &label, SimChannelVector &simChannelVector, bool &isValid)
+void LArPandoraHelper::CollectSimChannels(const art::Event &evt, const std::string &label, SimChannelVector &simChannelVector, bool &areSimChannelsValid)
 {
     if (evt.isRealData())
         throw cet::exception("LArPandora") << " PandoraCollector::CollectSimChannels --- Trying to access MC truth from real data ";
@@ -746,13 +746,13 @@ void LArPandoraHelper::CollectSimChannels(const art::Event &evt, const std::stri
     if (!theSimChannels.isValid())
     {
         mf::LogDebug("LArPandora") << "  Failed to find sim channels... " << std::endl;
-        isValid = false;
+        areSimChannelsValid = false;
         return;
     }
     else
     {
         mf::LogDebug("LArPandora") << "  Found: " << theSimChannels->size() << " SimChannels " << std::endl;
-        isValid = true;
+        areSimChannelsValid = true;
     }
 
     for (unsigned int i = 0; i < theSimChannels->size(); ++i)
@@ -978,8 +978,8 @@ void LArPandoraHelper::BuildMCParticleHitMaps(const art::Event &evt, const std::
     MCParticlesToMCTruth particlesToTruth;
     HitsToTrackIDEs hitsToTrackIDEs;
 
-    bool validSimChannels;
-    LArPandoraHelper::CollectSimChannels(evt, label, simChannelVector, validSimChannels);
+    bool areSimChannelsValid(false);
+    LArPandoraHelper::CollectSimChannels(evt, label, simChannelVector, areSimChannelsValid);
 
     LArPandoraHelper::CollectMCParticles(evt, label, truthToParticles, particlesToTruth);
     LArPandoraHelper::BuildMCParticleHitMaps(hitVector, simChannelVector, hitsToTrackIDEs);

--- a/larpandora/LArPandoraInterface/LArPandoraHelper.h
+++ b/larpandora/LArPandoraInterface/LArPandoraHelper.h
@@ -359,8 +359,9 @@ public:
      *  @param evt the ART event record
      *  @param label the label for the truth information in the event
      *  @param simChannelVector output vector of SimChannel objects
+     *  @param isValid boolean parameter indicating if the sim channel collection exists
      */
-    static void CollectSimChannels(const art::Event &evt, const std::string &label, SimChannelVector &simChannelVector);
+    static void CollectSimChannels(const art::Event &evt, const std::string &label, SimChannelVector &simChannelVector, bool &isValid);
 
     /**
      *  @brief Collect a vector of MCParticle objects from the ART event record

--- a/larpandora/LArPandoraInterface/LArPandoraHelper.h
+++ b/larpandora/LArPandoraInterface/LArPandoraHelper.h
@@ -359,9 +359,9 @@ public:
      *  @param evt the ART event record
      *  @param label the label for the truth information in the event
      *  @param simChannelVector output vector of SimChannel objects
-     *  @param isValid boolean parameter indicating if the sim channel collection exists
+     *  @param areSimChannelsValid boolean parameter indicating if the sim channel collection exists
      */
-    static void CollectSimChannels(const art::Event &evt, const std::string &label, SimChannelVector &simChannelVector, bool &isValid);
+    static void CollectSimChannels(const art::Event &evt, const std::string &label, SimChannelVector &simChannelVector, bool &areSimChannelsValid);
 
     /**
      *  @brief Collect a vector of MCParticle objects from the ART event record
@@ -611,8 +611,15 @@ public:
      *  @return true/false
      */
     static bool IsVisible(const art::Ptr<simb::MCParticle> particle);
-	
-	static larpandoraobj::PFParticleMetadata GetPFParticleMetadata(const pandora::ParticleFlowObject *const pPfo);
+
+    /**
+     *  @brief  Get metadata associated to a PFO
+     *
+     *  @param  pPfo input ParticleFlowObject
+     *
+     *  @return larpandoraobj::PFParticleMetadata
+     */
+    static larpandoraobj::PFParticleMetadata GetPFParticleMetadata(const pandora::ParticleFlowObject *const pPfo);
 };
 
 } // namespace lar_pandora


### PR DESCRIPTION
should happen only in empty BNB only events (i.e. DUNE FD), or customised MC productions producing somehow empty events