### PR TITLE
feature/PandoraDevelopmentArea

### DIFF
--- a/larpandora/LArPandoraInterface/LArPandora.cxx
+++ b/larpandora/LArPandoraInterface/LArPandora.cxx
@@ -78,6 +78,7 @@ LArPandora::LArPandora(fhicl::ParameterSet const &pset) :
     m_inputSettings.m_recombination_factor = pset.get<double>("RecombinationFactor", 0.63);
     m_outputSettings.m_pProducer = this;
     m_outputSettings.m_shouldRunStitching = m_shouldRunStitching;
+    m_outputSettings.m_shouldProduceSlices = pset.get<bool>("ShouldProduceSlices", true);
     m_outputSettings.m_isNeutrinoRecoOnlyNoSlicing = (!m_shouldRunSlicing && m_shouldRunNeutrinoRecoOption && !m_shouldRunCosmicRecoOption);
     m_outputSettings.m_hitfinderModuleLabel = m_hitfinderModuleLabel;
 
@@ -95,7 +96,6 @@ LArPandora::LArPandora(fhicl::ParameterSet const &pset) :
             produces< std::vector<recob::Cluster> >(instanceName);
             produces< std::vector<recob::Vertex> >(instanceName);
             produces< std::vector<larpandoraobj::PFParticleMetadata> >(instanceName);
-            produces< std::vector<recob::Slice> >(instanceName);
 
             produces< art::Assns<recob::PFParticle, larpandoraobj::PFParticleMetadata> >(instanceName);
             produces< art::Assns<recob::PFParticle, recob::SpacePoint> >(instanceName);
@@ -104,12 +104,17 @@ LArPandora::LArPandora(fhicl::ParameterSet const &pset) :
             produces< art::Assns<recob::PFParticle, recob::Slice> >(instanceName);
             produces< art::Assns<recob::SpacePoint, recob::Hit> >(instanceName);
             produces< art::Assns<recob::Cluster, recob::Hit> >(instanceName);
-            produces< art::Assns<recob::Slice, recob::Hit> >(instanceName);
 
             if (m_outputSettings.m_shouldRunStitching)
             {
                 produces< std::vector<anab::T0> >(instanceName);
                 produces< art::Assns<recob::PFParticle, anab::T0> >(instanceName);
+            }
+
+            if (m_outputSettings.m_shouldProduceSlices)
+            {
+                produces< std::vector<recob::Slice> >(instanceName);
+                produces< art::Assns<recob::Slice, recob::Hit> >(instanceName);
             }
         }
     }

--- a/larpandora/LArPandoraInterface/LArPandora.cxx
+++ b/larpandora/LArPandoraInterface/LArPandora.cxx
@@ -101,7 +101,6 @@ LArPandora::LArPandora(fhicl::ParameterSet const &pset) :
             produces< art::Assns<recob::PFParticle, recob::SpacePoint> >(instanceName);
             produces< art::Assns<recob::PFParticle, recob::Cluster> >(instanceName);
             produces< art::Assns<recob::PFParticle, recob::Vertex> >(instanceName);
-            produces< art::Assns<recob::PFParticle, recob::Slice> >(instanceName);
             produces< art::Assns<recob::SpacePoint, recob::Hit> >(instanceName);
             produces< art::Assns<recob::Cluster, recob::Hit> >(instanceName);
 
@@ -115,6 +114,7 @@ LArPandora::LArPandora(fhicl::ParameterSet const &pset) :
             {
                 produces< std::vector<recob::Slice> >(instanceName);
                 produces< art::Assns<recob::Slice, recob::Hit> >(instanceName);
+                produces< art::Assns<recob::PFParticle, recob::Slice> >(instanceName);
             }
         }
     }

--- a/larpandora/LArPandoraInterface/LArPandora.h
+++ b/larpandora/LArPandoraInterface/LArPandora.h
@@ -36,6 +36,9 @@ public:
     void produce(art::Event &evt);
 
 protected:
+    void CreatePandoraInput(art::Event &evt, IdToHitMap &idToHitMap);
+    void ProcessPandoraOutput(art::Event &evt, const IdToHitMap &idToHitMap);
+
     std::string                     m_configFile;                   ///< The config file
 
     bool                            m_shouldRunAllHitsCosmicReco;   ///< Steering: whether to run all hits cosmic-ray reconstruction
@@ -47,10 +50,6 @@ protected:
     bool                            m_shouldPerformSliceId;         ///< Steering: whether to identify slices and select most appropriate pfos
     bool                            m_shouldProduceAllOutcomes;     ///< Steering: whether to produce all reconstruction outcomes
     bool                            m_printOverallRecoStatus;       ///< Steering: whether to print current operation status messages
-
-private:
-    void CreatePandoraInput(art::Event &evt, IdToHitMap &idToHitMap);
-    void ProcessPandoraOutput(art::Event &evt, const IdToHitMap &idToHitMap);
 
     std::string                     m_generatorModuleLabel;         ///< The generator module label
     std::string                     m_geantModuleLabel;             ///< The geant module label

--- a/larpandora/LArPandoraInterface/LArPandoraInput.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraInput.cxx
@@ -52,7 +52,7 @@ void LArPandoraInput::CreatePandoraHits2D(const Settings &settings, const LArDri
     const bool isDualPhase(theGeometry->MaxPlanes() == 2);
 
     // Loop over ART hits
-    int hitCounter(0);
+    int hitCounter(settings.m_hitCounterOffset);
 
     lar_content::LArCaloHitFactory caloHitFactory;
 
@@ -776,6 +776,7 @@ LArPandoraInput::Settings::Settings() :
     m_useHitWidths(true),
     m_useBirksCorrection(false),
     m_uidOffset(100000000),
+    m_hitCounterOffset(0),
     m_dx_cm(0.5),
     m_int_cm(84.),
     m_rad_cm(14.),

--- a/larpandora/LArPandoraInterface/LArPandoraInput.h
+++ b/larpandora/LArPandoraInterface/LArPandoraInput.h
@@ -37,6 +37,7 @@ public:
         bool                    m_useHitWidths;             ///<
         bool                    m_useBirksCorrection;       ///<
         int                     m_uidOffset;                ///<
+        int                     m_hitCounterOffset;         ///<
         double                  m_dx_cm;                    ///<
         double                  m_int_cm;                   ///<
         double                  m_rad_cm;                   ///<

--- a/larpandora/LArPandoraInterface/LArPandoraOutput.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraOutput.cxx
@@ -100,7 +100,9 @@ void LArPandoraOutput::ProduceArtOutput(const Settings &settings, const IdToHitM
     LArPandoraOutput::BuildPFParticles(evt, settings.m_pProducer, instanceLabel, pfoVector, pfoToVerticesMap, pfoToThreeDHitsMap, pfoToArtClustersMap, outputParticles, outputParticlesToVertices, outputParticlesToSpacePoints, outputParticlesToClusters);
 
     LArPandoraOutput::BuildParticleMetadata(evt, settings.m_pProducer, instanceLabel, pfoVector, outputParticleMetadata, outputParticlesToMetadata);
-    LArPandoraOutput::BuildSlices(settings, settings.m_pPrimaryPandora, evt, settings.m_pProducer, instanceLabel, pfoVector, idToHitMap, outputSlices, outputParticlesToSlices, outputSlicesToHits);
+
+    if (settings.m_shouldProduceSlices)
+        LArPandoraOutput::BuildSlices(settings, settings.m_pPrimaryPandora, evt, settings.m_pProducer, instanceLabel, pfoVector, idToHitMap, outputSlices, outputParticlesToSlices, outputSlicesToHits);
 
     if (settings.m_shouldRunStitching)
         LArPandoraOutput::BuildT0s(evt, settings.m_pProducer, instanceLabel, pfoVector, outputT0s, outputParticlesToT0s);
@@ -111,7 +113,6 @@ void LArPandoraOutput::ProduceArtOutput(const Settings &settings, const IdToHitM
     evt.put(std::move(outputClusters), instanceLabel);
     evt.put(std::move(outputVertices), instanceLabel);
     evt.put(std::move(outputParticleMetadata), instanceLabel);
-    evt.put(std::move(outputSlices), instanceLabel);
 
     evt.put(std::move(outputParticlesToMetadata), instanceLabel);
     evt.put(std::move(outputParticlesToSpacePoints), instanceLabel);
@@ -120,12 +121,17 @@ void LArPandoraOutput::ProduceArtOutput(const Settings &settings, const IdToHitM
     evt.put(std::move(outputParticlesToSlices), instanceLabel);
     evt.put(std::move(outputSpacePointsToHits), instanceLabel);
     evt.put(std::move(outputClustersToHits), instanceLabel);
-    evt.put(std::move(outputSlicesToHits), instanceLabel);
 
     if (settings.m_shouldRunStitching)
     {
         evt.put(std::move(outputT0s), instanceLabel);
         evt.put(std::move(outputParticlesToT0s), instanceLabel);
+    }
+
+    if (settings.m_shouldProduceSlices)
+    {
+        evt.put(std::move(outputSlices), instanceLabel);
+        evt.put(std::move(outputSlicesToHits), instanceLabel);
     }
 }
 

--- a/larpandora/LArPandoraInterface/LArPandoraOutput.h
+++ b/larpandora/LArPandoraInterface/LArPandoraOutput.h
@@ -73,6 +73,7 @@ public:
         const pandora::Pandora *m_pPrimaryPandora;              ///<
         art::EDProducer        *m_pProducer;                    ///<
         bool                    m_shouldRunStitching;           ///<
+        bool                    m_shouldProduceSlices;          ///< Whether to produce output slices e.g. may not want to do this if only (re)processing single slices
         bool                    m_shouldProduceAllOutcomes;     ///< If all outcomes should be produced in separate collections (choose false if you only require the consolidated output)
         std::string             m_allOutcomesInstanceLabel;     ///< The label for the instance producing all outcomes
         bool                    m_isNeutrinoRecoOnlyNoSlicing;  ///< If we are running the neutrino reconstruction only with no slicing
@@ -88,7 +89,6 @@ public:
      */
     static void ProduceArtOutput(const Settings &settings, const IdToHitMap &idToHitMap, art::Event &evt);
 
-private:
     /**
      *  @brief  Get the address of a pandora instance with a given name
      *


### PR DESCRIPTION
Facilitate experiment-specific development, such as that in [ubreco](https://cdcvs.fnal.gov/redmine/projects/ubreco/repository?utf8=✓&rev=feature%2FPandoraDevelopmentArea).

The changes are essentially to allow slices to be reprocessed individually, and this requires moving some functionality into an experiment-specific module, hence change of the private member qualifier (pragmatic).

Reprocessing slices offers a number of complications, as it's very difficult to write out new slices in the new output (need a complete change to the way this is done right now, which just goes back to an input hit producer module...). Hence the option to just not write slices. In future, could try to copy the original input slices, but didn't have time for that right now.

Thanks!