### PR TITLE
Removed is real data checks

### DIFF
--- a/larpandora/LArPandoraAnalysis/PFParticleMonitoring_module.cc
+++ b/larpandora/LArPandoraAnalysis/PFParticleMonitoring_module.cc
@@ -548,23 +548,20 @@ void PFParticleMonitoring::analyze(const art::Event &evt)
     MCParticlesToHits trueParticlesToHits;
     HitsToMCParticles trueHitsToParticles;
 
-    if (!evt.isRealData())
+    LArPandoraHelper::CollectMCParticles(evt, m_geantModuleLabel, trueParticleVector);
+    LArPandoraHelper::CollectMCParticles(evt, m_geantModuleLabel, truthToParticles, particlesToTruth);
+
+    LArPandoraHelper::BuildMCParticleHitMaps(evt, m_geantModuleLabel, hitVector, trueParticlesToHits, trueHitsToParticles,
+        (m_useDaughterMCParticles ? (m_addDaughterMCParticles ? LArPandoraHelper::kAddDaughters : LArPandoraHelper::kUseDaughters) : LArPandoraHelper::kIgnoreDaughters));
+
+    if (trueHitsToParticles.empty())
     {
-        LArPandoraHelper::CollectMCParticles(evt, m_geantModuleLabel, trueParticleVector);
-        LArPandoraHelper::CollectMCParticles(evt, m_geantModuleLabel, truthToParticles, particlesToTruth);
+        if (m_backtrackerLabel.empty())
+            throw cet::exception("LArPandora") << " PFParticleMonitoring::analyze - no sim channels found, backtracker module must be set in FHiCL " << std::endl;
 
-        LArPandoraHelper::BuildMCParticleHitMaps(evt, m_geantModuleLabel, hitVector, trueParticlesToHits, trueHitsToParticles,
+        LArPandoraHelper::BuildMCParticleHitMaps(evt, m_geantModuleLabel, m_hitfinderLabel, m_backtrackerLabel,
+            trueParticlesToHits, trueHitsToParticles,
             (m_useDaughterMCParticles ? (m_addDaughterMCParticles ? LArPandoraHelper::kAddDaughters : LArPandoraHelper::kUseDaughters) : LArPandoraHelper::kIgnoreDaughters));
-
-        if (trueHitsToParticles.empty())
-        {
-            if (m_backtrackerLabel.empty())
-                throw cet::exception("LArPandora") << " PFParticleMonitoring::analyze - no sim channels found, backtracker module must be set in FHiCL " << std::endl;
-
-            LArPandoraHelper::BuildMCParticleHitMaps(evt, m_geantModuleLabel, m_hitfinderLabel, m_backtrackerLabel,
-                trueParticlesToHits, trueHitsToParticles,
-                (m_useDaughterMCParticles ? (m_addDaughterMCParticles ? LArPandoraHelper::kAddDaughters : LArPandoraHelper::kUseDaughters) : LArPandoraHelper::kIgnoreDaughters));
-        }
     }
 
     if (m_printDebug)

--- a/larpandora/LArPandoraInterface/LArPandora.cxx
+++ b/larpandora/LArPandoraInterface/LArPandora.cxx
@@ -193,7 +193,7 @@ void LArPandora::CreatePandoraInput(art::Event &evt, IdToHitMap &idToHitMap)
 
     LArPandoraHelper::CollectHits(evt, m_hitfinderModuleLabel, artHits);
 
-    if (m_enableMCParticles && !evt.isRealData())
+    if (m_enableMCParticles)
     {
         LArPandoraHelper::CollectMCParticles(evt, m_geantModuleLabel, artMCParticleVector);
 
@@ -223,7 +223,7 @@ void LArPandora::CreatePandoraInput(art::Event &evt, IdToHitMap &idToHitMap)
 
     LArPandoraInput::CreatePandoraHits2D(m_inputSettings, m_driftVolumeMap, artHits, idToHitMap);
 
-    if (m_enableMCParticles && !evt.isRealData())
+    if (m_enableMCParticles)
     {
         LArPandoraInput::CreatePandoraMCParticles(m_inputSettings, artMCTruthToMCParticles, artMCParticlesToMCTruth, generatorArtMCParticleVector);
         LArPandoraInput::CreatePandoraMCLinks2D(m_inputSettings, idToHitMap, artHitsToTrackIDEs);

--- a/larpandora/LArPandoraInterface/LArPandoraHelper.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraHelper.cxx
@@ -737,9 +737,6 @@ void LArPandoraHelper::CollectT0s(const art::Event &evt, const std::string &labe
 
 void LArPandoraHelper::CollectSimChannels(const art::Event &evt, const std::string &label, SimChannelVector &simChannelVector, bool &areSimChannelsValid)
 {
-    if (evt.isRealData())
-        throw cet::exception("LArPandora") << " PandoraCollector::CollectSimChannels --- Trying to access MC truth from real data ";
-
     art::Handle< std::vector<sim::SimChannel> > theSimChannels;
     evt.getByLabel(label, theSimChannels);
 
@@ -766,9 +763,6 @@ void LArPandoraHelper::CollectSimChannels(const art::Event &evt, const std::stri
 
 void LArPandoraHelper::CollectMCParticles(const art::Event &evt, const std::string &label, MCParticleVector &particleVector)
 {
-    if (evt.isRealData())
-        throw cet::exception("LArPandora") << " PandoraCollector::CollectMCParticles --- Trying to access MC truth from real data ";
-
     art::Handle< RawMCParticleVector > theParticles;
     evt.getByLabel(label, theParticles);
 
@@ -793,9 +787,6 @@ void LArPandoraHelper::CollectMCParticles(const art::Event &evt, const std::stri
 
 void LArPandoraHelper::CollectGeneratorMCParticles(const art::Event &evt, const std::string &label, RawMCParticleVector &particleVector)
 {
-    if (evt.isRealData())
-        throw cet::exception("LArPandora") << " PandoraCollector::CollectGeneratorMCParticles --- Trying to access MC truth from real data ";
-
     art::Handle< std::vector<simb::MCTruth> > mcTruthBlocks;
     evt.getByLabel(label, mcTruthBlocks);
 
@@ -826,9 +817,6 @@ void LArPandoraHelper::CollectGeneratorMCParticles(const art::Event &evt, const 
 void LArPandoraHelper::CollectMCParticles(const art::Event &evt, const std::string &label, MCTruthToMCParticles &truthToParticles,
     MCParticlesToMCTruth &particlesToTruth)
 {
-    if (evt.isRealData())
-        throw cet::exception("LArPandora") << " PandoraCollector::CollectMCParticles --- Trying to access MC truth from real data ";
-
     art::Handle< RawMCParticleVector > theParticles;
     evt.getByLabel(label, theParticles);
 


### PR DESCRIPTION
Removed the checks for `art::Event::isRealData()` throughout larpandora. These checks raised an exception if the user attempts to access truth information from a "real data" file. These checks were causing issues for MicroBooNE which overlays MC on top of real (cosmic) data, and so the exceptions were being raised even though there was MC information available.

The code now relies on the error checking provided by art (e.g. `event.getByLabel()`) which will still raise an exception if the user attempts to access truth information that isn't available in the input file.