### PR TITLE
Feature/dp gaps pr

### DIFF
--- a/larpandora/LArPandoraInterface/LArPandoraGeometry.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraGeometry.cxx
@@ -29,57 +29,76 @@ void LArPandoraGeometry::LoadDetectorGaps(LArDetectorGapList &listOfGaps)
     LArDriftVolumeList driftVolumeList;
     LArPandoraGeometry::LoadGeometry(driftVolumeList);
 
+    // ATTN: Expectations here are that the input geometry corresponds to either a single or dual phase LArTPC.
+    art::ServiceHandle<geo::Geometry const> theGeometry;
+    const bool isDualPhase(theGeometry->MaxPlanes() == 2);
+
     for (LArDriftVolumeList::const_iterator iter1 = driftVolumeList.begin(), iterEnd1 = driftVolumeList.end(); iter1 != iterEnd1; ++iter1)
     {
         const LArDriftVolume &driftVolume1 = *iter1;
-
+        
+        
         for (LArDriftVolumeList::const_iterator iter2 = iter1, iterEnd2 = driftVolumeList.end(); iter2 != iterEnd2; ++iter2)
         {
             const LArDriftVolume &driftVolume2 = *iter2;
-
+            
             if (driftVolume1.GetVolumeID() == driftVolume2.GetVolumeID())
                 continue;
 
             const float maxDisplacement(30.f); // TODO: 30cm should be fine, but can we do better than a hard-coded number here?
-            const float deltaZ(std::fabs(driftVolume1.GetCenterZ() - driftVolume2.GetCenterZ()));
-            const float deltaY(std::fabs(driftVolume1.GetCenterY() - driftVolume2.GetCenterY()));
+
             const float deltaX(std::fabs(driftVolume1.GetCenterX() - driftVolume2.GetCenterX()));
+            const float deltaY(std::fabs(driftVolume1.GetCenterY() - driftVolume2.GetCenterY()));
+            const float deltaZ(std::fabs(driftVolume1.GetCenterZ() - driftVolume2.GetCenterZ()));
+            
             const float widthX(0.5f * (driftVolume1.GetWidthX() + driftVolume2.GetWidthX()));
+            const float widthY(0.5f * (driftVolume1.GetWidthY() + driftVolume2.GetWidthY()));
+            const float widthZ(0.5f * (driftVolume1.GetWidthZ() + driftVolume2.GetWidthZ()));
+            
             const float gapX(deltaX - widthX);
-
-            if (gapX < 0.f || gapX > maxDisplacement || deltaY > maxDisplacement || deltaZ > maxDisplacement)
+            const float gapY(deltaY - widthY);
+            const float gapZ(deltaZ - widthZ);
+            
+            if (!isDualPhase && (gapX < 0.f || gapX > maxDisplacement || deltaY > maxDisplacement || deltaZ > maxDisplacement))
                 continue;
-
+            
             const float X1((driftVolume1.GetCenterX() < driftVolume2.GetCenterX()) ? (driftVolume1.GetCenterX() + 0.5f * driftVolume1.GetWidthX()) :
-                (driftVolume2.GetCenterX() + 0.5f * driftVolume2.GetWidthX()));
+                           (driftVolume2.GetCenterX() + 0.5f * driftVolume2.GetWidthX()));
             const float X2((driftVolume1.GetCenterX() > driftVolume2.GetCenterX()) ? (driftVolume1.GetCenterX() - 0.5f * driftVolume1.GetWidthX()) :
-                (driftVolume2.GetCenterX() - 0.5f * driftVolume2.GetWidthX()));
+                           (driftVolume2.GetCenterX() - 0.5f * driftVolume2.GetWidthX()));
             const float Y1(std::min((driftVolume1.GetCenterY() - 0.5f * driftVolume1.GetWidthY()),
-                (driftVolume2.GetCenterY() - 0.5f * driftVolume2.GetWidthY())));
+                                    (driftVolume2.GetCenterY() - 0.5f * driftVolume2.GetWidthY())));
             const float Y2(std::max((driftVolume1.GetCenterY() + 0.5f * driftVolume1.GetWidthY()),
-                (driftVolume2.GetCenterY() + 0.5f * driftVolume2.GetWidthY())));
+                                    (driftVolume2.GetCenterY() + 0.5f * driftVolume2.GetWidthY())));
             const float Z1(std::min((driftVolume1.GetCenterZ() - 0.5f * driftVolume1.GetWidthZ()),
-                (driftVolume2.GetCenterZ() - 0.5f * driftVolume2.GetWidthZ())));
+                                    (driftVolume2.GetCenterZ() - 0.5f * driftVolume2.GetWidthZ())));
             const float Z2(std::max((driftVolume1.GetCenterZ() + 0.5f * driftVolume1.GetWidthZ()),
-                (driftVolume2.GetCenterZ() + 0.5f * driftVolume2.GetWidthZ())));
+                                    (driftVolume2.GetCenterZ() + 0.5f * driftVolume2.GetWidthZ())));
+            
+            if (isDualPhase && (std::fabs(gapY) > maxDisplacement || std::fabs(gapZ) > maxDisplacement))
+            {
+                listOfGaps.push_back(LArDetectorGap(X1, Y1 + widthY, Z1 + widthY, X2, Y2 - widthY, Z2 - widthZ));
+                continue;
+            }
 
-            listOfGaps.push_back(LArDetectorGap(X1, Y1, Z1, X2, Y2, Z2));
+            if (!isDualPhase)
+                listOfGaps.push_back(LArDetectorGap(X1, Y1, Z1, X2, Y2, Z2));
         }
     }
 }
-
+    
 //------------------------------------------------------------------------------------------------------------------------------------------
-
+    
 void LArPandoraGeometry::LoadGeometry(LArDriftVolumeList &outputVolumeList, LArDriftVolumeMap &outputVolumeMap)
 {
     if (!outputVolumeList.empty())
         throw cet::exception("LArPandora") << " LArPandoraGeometry::LoadGeometry --- the list of drift volumes already exists ";
-
+    
     // Use a global coordinate system but keep drift volumes separate
     LArDriftVolumeList inputVolumeList;
     LArPandoraGeometry::LoadGeometry(inputVolumeList);
     LArPandoraGeometry::LoadGlobalDaughterGeometry(inputVolumeList, outputVolumeList);
-
+    
     // Create mapping between tpc/cstat labels and drift volumes
     for (const LArDriftVolume &driftVolume : outputVolumeList)
     {
@@ -96,21 +115,21 @@ unsigned int LArPandoraGeometry::GetVolumeID(const LArDriftVolumeMap &driftVolum
 {
     if (driftVolumeMap.empty())
         throw cet::exception("LArPandora") << " LArPandoraGeometry::GetVolumeID --- detector geometry map is empty";
-
+    
     LArDriftVolumeMap::const_iterator iter = driftVolumeMap.find(LArPandoraGeometry::GetTpcID(cstat, tpc));
-
+    
     if (driftVolumeMap.end() == iter)
         throw cet::exception("LArPandora") << " LArPandoraGeometry::GetVolumeID --- found a TPC that doesn't belong to a drift volume";
-
+    
     return iter->second.GetVolumeID();
 }
-
+    
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 geo::View_t LArPandoraGeometry::GetGlobalView(const unsigned int cstat, const unsigned int tpc, const geo::View_t hit_View)
 {
     const bool switchUV(LArPandoraGeometry::ShouldSwitchUV(cstat, tpc));
-
+    
     // ATTN This implicitly assumes that there will be u, v and (maybe) one of either w or y views
     if ((hit_View == geo::kW) || (hit_View == geo::kY))
     {
@@ -176,61 +195,61 @@ void LArPandoraGeometry::LoadGeometry(LArDriftVolumeList &driftVolumeList)
         throw cet::exception("LArPandora") << " LArPandoraGeometry::LoadGeometry --- detector geometry has already been loaded ";
 
     typedef std::set<unsigned int> UIntSet;
-
+    
     // Pandora requires three independent images, and ability to correlate features between images (via wire angles and transformation plugin).
     art::ServiceHandle<geo::Geometry const> theGeometry;
     const unsigned int nWirePlanes(theGeometry->MaxPlanes());
-
+    
     if (nWirePlanes > 3)
         throw cet::exception("LArPandora") << " LArPandoraGeometry::LoadGeometry --- More than three wire planes present ";
-
+    
     // We here check the plane information only for the first tpc in the first cryostat.
     if ((0 == theGeometry->Ncryostats()) || (0 == theGeometry->NTPC(0)))
         throw cet::exception("LArPandora") << " LArPandoraGeometry::LoadGeometry --- unable to access first tpc in first cryostat ";
-
+    
     std::unordered_set<geo::_plane_proj> planeSet;
     for (unsigned int iPlane = 0; iPlane < nWirePlanes; ++iPlane)
         (void) planeSet.insert(theGeometry->TPC(0, 0).Plane(iPlane).View());
-
+    
     // ATTN: Expectations here are that the input geometry corresponds to either a single or dual phase LArTPC.  For single phase we expect
     // three views, U, V and either W or Y, for dual phase we expect two views, W and Y.
     const bool isDualPhase(theGeometry->MaxPlanes() == 2);
-
+    
     if (nWirePlanes != planeSet.size())
         throw cet::exception("LArPandora") << " LArPandoraGeometry::LoadGeometry --- geometry description for wire plane(s) missing ";
-
+    
     if (isDualPhase && (!planeSet.count(geo::kW) || !planeSet.count(geo::kY)))
         throw cet::exception("LArPandora") << " LArPandoraGeometry::LoadGeometry --- dual phase scenario; expect to find w and y views ";
-
+    
     if (!isDualPhase && (!planeSet.count(geo::kU) || !planeSet.count(geo::kV) || (planeSet.count(geo::kW) && planeSet.count(geo::kY))))
         throw cet::exception("LArPandora") << " LArPandoraGeometry::LoadGeometry --- single phase scenatio; expect to find u and v views; if there is one further view, it must be w or y ";
-
+    
     const bool useYPlane((nWirePlanes > 2) && planeSet.count(geo::kY));
-
+    
     // ATTN: In the dual phase mode, map the wire planes as follows W->U and Y->V.  This mapping was chosen so that the dual phase wire
     // planes, which are inherently induction only, are mapped to induction planes in the single phase geometry.
     const float wirePitchU(theGeometry->WirePitch((isDualPhase ? geo::kW : geo::kU)));
     const float wirePitchV(theGeometry->WirePitch((isDualPhase ? geo::kY : geo::kV)));
     const float wirePitchW((nWirePlanes < 3) ? 0.5f * (wirePitchU + wirePitchV) : (useYPlane) ? theGeometry->WirePitch(geo::kY) :
-        theGeometry->WirePitch(geo::kW));
-
+                           theGeometry->WirePitch(geo::kW));
+    
     const float maxDeltaTheta(0.01f); // leave this hard-coded for now
-
+    
     // Loop over cryostats
     for (unsigned int icstat = 0; icstat < theGeometry->Ncryostats(); ++icstat)
     {
         UIntSet cstatList;
-
+        
         // Loop over TPCs in in this cryostat
         for (unsigned int itpc1 = 0; itpc1 < theGeometry->NTPC(icstat); ++itpc1)
         {
             if (cstatList.end() != cstatList.find(itpc1))
                 continue;
-
+            
             // Use this TPC to seed a drift volume
             const geo::TPCGeo &theTpc1(theGeometry->TPC(itpc1, icstat));
             cstatList.insert(itpc1);
-
+            
             // ATTN: In dual phase scenario propagate the W->U and Y->V mapping and set wire angle for remaining view to epsilon to
             // avoid identical wire angles clashes (dual phase W and Y wires are horizontal and vertical).  Inside LArSoft the
             // WireAngleToVertical function returns the wire angle to the positive Z axis, but Pandora expects to receive the wire
@@ -241,84 +260,117 @@ void LArPandoraGeometry::LoadGeometry(LArDriftVolumeList &driftVolumeList)
             const float wireAngleU(0.5f * M_PI - theGeometry->WireAngleToVertical(targetViewU, itpc1, icstat));
             const float wireAngleV(0.5f * M_PI - theGeometry->WireAngleToVertical(targetViewV, itpc1, icstat));
             const float wireAngleW((nWirePlanes < 3) ? std::numeric_limits<float>::epsilon() : (useYPlane) ? (std::fabs(0.5f * M_PI - theGeometry->WireAngleToVertical(geo::kY, itpc1, icstat))) :
-                (0.5f * M_PI - theGeometry->WireAngleToVertical(geo::kW, itpc1, icstat)));
-
+                                   (0.5f * M_PI - theGeometry->WireAngleToVertical(geo::kW, itpc1, icstat)));
+            
             double localCoord1[3] = {0., 0., 0.};
             double worldCoord1[3] = {0., 0., 0.};
             theTpc1.LocalToWorld(localCoord1, worldCoord1);
-
+            
             const double min1(worldCoord1[0] - 0.5 * theTpc1.ActiveHalfWidth());
             const double max1(worldCoord1[0] + 0.5 * theTpc1.ActiveHalfWidth());
-
+            
             float driftMinX(worldCoord1[0] - theTpc1.ActiveHalfWidth());
             float driftMaxX(worldCoord1[0] + theTpc1.ActiveHalfWidth());
             float driftMinY(worldCoord1[1] - theTpc1.ActiveHalfHeight());
             float driftMaxY(worldCoord1[1] + theTpc1.ActiveHalfHeight());
             float driftMinZ(worldCoord1[2] - 0.5f * theTpc1.ActiveLength());
             float driftMaxZ(worldCoord1[2] + 0.5f * theTpc1.ActiveLength());
-
+            
             const bool isPositiveDrift(theTpc1.DriftDirection() == geo::kPosX);
-
+            
             UIntSet tpcList;
             tpcList.insert(itpc1);
-
+            
+            if (isDualPhase)
+            {
+                LArDaughterDriftVolumeList tpcVolumeList;
+                tpcVolumeList.push_back(LArDaughterDriftVolume(icstat, itpc1));
+                
+                driftVolumeList.push_back(LArDriftVolume(driftVolumeList.size(), isPositiveDrift,
+                                                         wirePitchU, wirePitchV, wirePitchW, wireAngleU, wireAngleV, wireAngleW,
+                                                         0.5f * (driftMaxX + driftMinX), 0.5f * (driftMaxY + driftMinY), 0.5f * (driftMaxZ + driftMinZ),
+                                                         (driftMaxX - driftMinX), (driftMaxY - driftMinY), (driftMaxZ - driftMinZ),
+                                                         (wirePitchU + wirePitchV + wirePitchW + 0.1f), tpcVolumeList));
+                
+            }
             // Now identify the other TPCs associated with this drift volume
             for (unsigned int itpc2 = itpc1+1; itpc2 < theGeometry->NTPC(icstat); ++itpc2)
             {
                 if (cstatList.end() != cstatList.find(itpc2))
                     continue;
-
+                
                 const geo::TPCGeo &theTpc2(theGeometry->TPC(itpc2, icstat));
-
+                
                 if (theTpc1.DriftDirection() != theTpc2.DriftDirection())
                     continue;
-
+                
                 // ATTN: In dual phase scenario propagate the W->U and Y->V mapping as described above.
                 const geo::View_t pandoraUView(isDualPhase ? geo::kW : geo::kU);
                 const geo::View_t pandoraVView(isDualPhase ? geo::kY : geo::kV);
                 const float dThetaU(theGeometry->WireAngleToVertical(pandoraUView, itpc1, icstat) - theGeometry->WireAngleToVertical(pandoraUView, itpc2, icstat));
                 const float dThetaV(theGeometry->WireAngleToVertical(pandoraVView, itpc1, icstat) - theGeometry->WireAngleToVertical(pandoraVView, itpc2, icstat));
                 const float dThetaW((nWirePlanes < 3) ? std::numeric_limits<float>::epsilon() : (useYPlane) ? (theGeometry->WireAngleToVertical(geo::kY, itpc1, icstat) - theGeometry->WireAngleToVertical(geo::kY, itpc2, icstat)) :
-                    (theGeometry->WireAngleToVertical(geo::kW, itpc1, icstat) - theGeometry->WireAngleToVertical(geo::kW, itpc2, icstat)));
-
+                                    (theGeometry->WireAngleToVertical(geo::kW, itpc1, icstat) - theGeometry->WireAngleToVertical(geo::kW, itpc2, icstat)));
+                
                 if (dThetaU > maxDeltaTheta || dThetaV > maxDeltaTheta || dThetaW > maxDeltaTheta)
                     continue;
-
+                
                 double localCoord2[3] = {0., 0., 0.};
                 double worldCoord2[3] = {0., 0., 0.};
                 theTpc2.LocalToWorld(localCoord2, worldCoord2);
-
+                
                 const double min2(worldCoord2[0] - 0.5 * theTpc2.ActiveHalfWidth());
                 const double max2(worldCoord2[0] + 0.5 * theTpc2.ActiveHalfWidth());
-
+                
                 if ((min2 > max1) || (min1 > max2))
                     continue;
-
+                
                 cstatList.insert(itpc2);
                 tpcList.insert(itpc2);
-
-                driftMinX = std::min(driftMinX, static_cast<float>(worldCoord2[0] - theTpc2.ActiveHalfWidth()));
-                driftMaxX = std::max(driftMaxX, static_cast<float>(worldCoord2[0] + theTpc2.ActiveHalfWidth()));
-                driftMinY = std::min(driftMinY, static_cast<float>(worldCoord2[1] - theTpc2.ActiveHalfHeight()));
-                driftMaxY = std::max(driftMaxY, static_cast<float>(worldCoord2[1] + theTpc2.ActiveHalfHeight()));
-                driftMinZ = std::min(driftMinZ, static_cast<float>(worldCoord2[2] - 0.5f * theTpc2.ActiveLength()));
-                driftMaxZ = std::max(driftMaxZ, static_cast<float>(worldCoord2[2] + 0.5f * theTpc2.ActiveLength()));
+                
+                float driftMinX2(worldCoord2[0] - theTpc2.ActiveHalfWidth());
+                float driftMaxX2(worldCoord2[0] + theTpc2.ActiveHalfWidth());
+                float driftMinY2(worldCoord2[1] - theTpc2.ActiveHalfHeight());
+                float driftMaxY2(worldCoord2[1] + theTpc2.ActiveHalfHeight());
+                float driftMinZ2(worldCoord2[2] - 0.5f * theTpc2.ActiveLength());
+                float driftMaxZ2(worldCoord2[2] + 0.5f * theTpc2.ActiveLength());
+                
+                driftMinX = std::min(driftMinX, driftMinX2);
+                driftMaxX = std::max(driftMaxX, driftMaxX2);
+                driftMinY = std::min(driftMinY, driftMinY2);
+                driftMaxY = std::max(driftMaxY, driftMaxY2);
+                driftMinZ = std::min(driftMinZ, driftMinZ2);
+                driftMaxZ = std::max(driftMaxZ, driftMaxZ2);
+                
+                if (isDualPhase)
+                {
+                    LArDaughterDriftVolumeList tpcVolumeList;
+                    tpcVolumeList.push_back(LArDaughterDriftVolume(icstat, itpc2));
+                    
+                    driftVolumeList.push_back(LArDriftVolume(driftVolumeList.size(), isPositiveDrift,
+                                                             wirePitchU, wirePitchV, wirePitchW, wireAngleU, wireAngleV, wireAngleW,
+                                                             0.5f * (driftMaxX2 + driftMinX2), 0.5f * (driftMaxY2 + driftMinY2), 0.5f * (driftMaxZ2 + driftMinZ2),
+                                                             (driftMaxX2 - driftMinX2), (driftMaxY2 - driftMinY2), (driftMaxZ2 - driftMinZ2),
+                                                             (wirePitchU + wirePitchV + wirePitchW + 0.1f), tpcVolumeList));
+                }
+                
             }
-
+            
             // Collate the tpc volumes in this drift volume
             LArDaughterDriftVolumeList tpcVolumeList;
-
+            
             for(const unsigned int itpc : tpcList)
             {
                 tpcVolumeList.push_back(LArDaughterDriftVolume(icstat, itpc));
             }
-
+            
             // Create new daughter drift volume (volume ID = 0 to N-1)
-            driftVolumeList.push_back(LArDriftVolume(driftVolumeList.size(), isPositiveDrift,
-                wirePitchU, wirePitchV, wirePitchW, wireAngleU, wireAngleV, wireAngleW,
-                0.5f * (driftMaxX + driftMinX), 0.5f * (driftMaxY + driftMinY), 0.5f * (driftMaxZ + driftMinZ),
-                (driftMaxX - driftMinX), (driftMaxY - driftMinY), (driftMaxZ - driftMinZ),
-                (wirePitchU + wirePitchV + wirePitchW + 0.1f), tpcVolumeList));
+            if (!isDualPhase)
+                driftVolumeList.push_back(LArDriftVolume(driftVolumeList.size(), isPositiveDrift,
+                                                         wirePitchU, wirePitchV, wirePitchW, wireAngleU, wireAngleV, wireAngleW,
+                                                         0.5f * (driftMaxX + driftMinX), 0.5f * (driftMaxY + driftMinY), 0.5f * (driftMaxZ + driftMinZ),
+                                                         (driftMaxX - driftMinX), (driftMaxY - driftMinY), (driftMaxZ - driftMinZ),
+                                                         (wirePitchU + wirePitchV + wirePitchW + 0.1f), tpcVolumeList));
         }
     }
 

--- a/larpandora/LArPandoraInterface/LArPandoraGeometry.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraGeometry.cxx
@@ -36,11 +36,11 @@ void LArPandoraGeometry::LoadDetectorGaps(LArDetectorGapList &listOfGaps)
     for (LArDriftVolumeList::const_iterator iter1 = driftVolumeList.begin(), iterEnd1 = driftVolumeList.end(); iter1 != iterEnd1; ++iter1)
     {
         const LArDriftVolume &driftVolume1 = *iter1;
-        
+
         for (LArDriftVolumeList::const_iterator iter2 = iter1, iterEnd2 = driftVolumeList.end(); iter2 != iterEnd2; ++iter2)
         {
             const LArDriftVolume &driftVolume2 = *iter2;
-            
+
             if (driftVolume1.GetVolumeID() == driftVolume2.GetVolumeID())
                 continue;
 
@@ -49,18 +49,18 @@ void LArPandoraGeometry::LoadDetectorGaps(LArDetectorGapList &listOfGaps)
             const float deltaX(std::fabs(driftVolume1.GetCenterX() - driftVolume2.GetCenterX()));
             const float deltaY(std::fabs(driftVolume1.GetCenterY() - driftVolume2.GetCenterY()));
             const float deltaZ(std::fabs(driftVolume1.GetCenterZ() - driftVolume2.GetCenterZ()));
-            
+
             const float widthX(0.5f * (driftVolume1.GetWidthX() + driftVolume2.GetWidthX()));
             const float widthY(0.5f * (driftVolume1.GetWidthY() + driftVolume2.GetWidthY()));
             const float widthZ(0.5f * (driftVolume1.GetWidthZ() + driftVolume2.GetWidthZ()));
-            
+
             const float gapX(deltaX - widthX);
             const float gapY(deltaY - widthY);
             const float gapZ(deltaZ - widthZ);
-            
+
             if (!isDualPhase && (gapX < 0.f || gapX > maxDisplacement || deltaY > maxDisplacement || deltaZ > maxDisplacement))
                 continue;
-            
+
             const float X1((driftVolume1.GetCenterX() < driftVolume2.GetCenterX()) ? (driftVolume1.GetCenterX() + 0.5f * driftVolume1.GetWidthX()) :
                 (driftVolume2.GetCenterX() + 0.5f * driftVolume2.GetWidthX()));
             const float X2((driftVolume1.GetCenterX() > driftVolume2.GetCenterX()) ? (driftVolume1.GetCenterX() - 0.5f * driftVolume1.GetWidthX()) :
@@ -73,7 +73,7 @@ void LArPandoraGeometry::LoadDetectorGaps(LArDetectorGapList &listOfGaps)
                 (driftVolume2.GetCenterZ() - 0.5f * driftVolume2.GetWidthZ())));
             const float Z2(std::max((driftVolume1.GetCenterZ() + 0.5f * driftVolume1.GetWidthZ()),
                 (driftVolume2.GetCenterZ() + 0.5f * driftVolume2.GetWidthZ())));
-            
+
             if (isDualPhase && (std::fabs(gapY) > maxDisplacement || std::fabs(gapZ) > maxDisplacement))
                 listOfGaps.push_back(LArDetectorGap(X1, Y1 + widthY, Z1 + widthZ, X2, Y2 - widthY, Z2 - widthZ));
 
@@ -82,19 +82,19 @@ void LArPandoraGeometry::LoadDetectorGaps(LArDetectorGapList &listOfGaps)
         }
     }
 }
-    
+
 //------------------------------------------------------------------------------------------------------------------------------------------
-    
+
 void LArPandoraGeometry::LoadGeometry(LArDriftVolumeList &outputVolumeList, LArDriftVolumeMap &outputVolumeMap)
 {
     if (!outputVolumeList.empty())
         throw cet::exception("LArPandora") << " LArPandoraGeometry::LoadGeometry --- the list of drift volumes already exists ";
-    
+
     // Use a global coordinate system but keep drift volumes separate
     LArDriftVolumeList inputVolumeList;
     LArPandoraGeometry::LoadGeometry(inputVolumeList);
     LArPandoraGeometry::LoadGlobalDaughterGeometry(inputVolumeList, outputVolumeList);
-    
+
     // Create mapping between tpc/cstat labels and drift volumes
     for (const LArDriftVolume &driftVolume : outputVolumeList)
     {
@@ -111,21 +111,21 @@ unsigned int LArPandoraGeometry::GetVolumeID(const LArDriftVolumeMap &driftVolum
 {
     if (driftVolumeMap.empty())
         throw cet::exception("LArPandora") << " LArPandoraGeometry::GetVolumeID --- detector geometry map is empty";
-    
+
     LArDriftVolumeMap::const_iterator iter = driftVolumeMap.find(LArPandoraGeometry::GetTpcID(cstat, tpc));
-    
+
     if (driftVolumeMap.end() == iter)
         throw cet::exception("LArPandora") << " LArPandoraGeometry::GetVolumeID --- found a TPC that doesn't belong to a drift volume";
-    
+
     return iter->second.GetVolumeID();
 }
-    
+
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 geo::View_t LArPandoraGeometry::GetGlobalView(const unsigned int cstat, const unsigned int tpc, const geo::View_t hit_View)
 {
     const bool switchUV(LArPandoraGeometry::ShouldSwitchUV(cstat, tpc));
-    
+
     // ATTN This implicitly assumes that there will be u, v and (maybe) one of either w or y views
     if ((hit_View == geo::kW) || (hit_View == geo::kY))
     {
@@ -191,61 +191,61 @@ void LArPandoraGeometry::LoadGeometry(LArDriftVolumeList &driftVolumeList)
         throw cet::exception("LArPandora") << " LArPandoraGeometry::LoadGeometry --- detector geometry has already been loaded ";
 
     typedef std::set<unsigned int> UIntSet;
-    
+
     // Pandora requires three independent images, and ability to correlate features between images (via wire angles and transformation plugin).
     art::ServiceHandle<geo::Geometry const> theGeometry;
     const unsigned int nWirePlanes(theGeometry->MaxPlanes());
-    
+
     if (nWirePlanes > 3)
         throw cet::exception("LArPandora") << " LArPandoraGeometry::LoadGeometry --- More than three wire planes present ";
-    
+
     // We here check the plane information only for the first tpc in the first cryostat.
     if ((0 == theGeometry->Ncryostats()) || (0 == theGeometry->NTPC(0)))
         throw cet::exception("LArPandora") << " LArPandoraGeometry::LoadGeometry --- unable to access first tpc in first cryostat ";
-    
+
     std::unordered_set<geo::_plane_proj> planeSet;
     for (unsigned int iPlane = 0; iPlane < nWirePlanes; ++iPlane)
         (void) planeSet.insert(theGeometry->TPC(0, 0).Plane(iPlane).View());
-    
+
     // ATTN: Expectations here are that the input geometry corresponds to either a single or dual phase LArTPC.  For single phase we expect
     // three views, U, V and either W or Y, for dual phase we expect two views, W and Y.
     const bool isDualPhase(theGeometry->MaxPlanes() == 2);
-    
+
     if (nWirePlanes != planeSet.size())
         throw cet::exception("LArPandora") << " LArPandoraGeometry::LoadGeometry --- geometry description for wire plane(s) missing ";
-    
+
     if (isDualPhase && (!planeSet.count(geo::kW) || !planeSet.count(geo::kY)))
         throw cet::exception("LArPandora") << " LArPandoraGeometry::LoadGeometry --- dual phase scenario; expect to find w and y views ";
-    
+
     if (!isDualPhase && (!planeSet.count(geo::kU) || !planeSet.count(geo::kV) || (planeSet.count(geo::kW) && planeSet.count(geo::kY))))
         throw cet::exception("LArPandora") << " LArPandoraGeometry::LoadGeometry --- single phase scenatio; expect to find u and v views; if there is one further view, it must be w or y ";
-    
+
     const bool useYPlane((nWirePlanes > 2) && planeSet.count(geo::kY));
-    
+
     // ATTN: In the dual phase mode, map the wire planes as follows W->U and Y->V.  This mapping was chosen so that the dual phase wire
     // planes, which are inherently induction only, are mapped to induction planes in the single phase geometry.
     const float wirePitchU(theGeometry->WirePitch((isDualPhase ? geo::kW : geo::kU)));
     const float wirePitchV(theGeometry->WirePitch((isDualPhase ? geo::kY : geo::kV)));
     const float wirePitchW((nWirePlanes < 3) ? 0.5f * (wirePitchU + wirePitchV) : (useYPlane) ? theGeometry->WirePitch(geo::kY) :
                            theGeometry->WirePitch(geo::kW));
-    
+
     const float maxDeltaTheta(0.01f); // leave this hard-coded for now
-    
+
     // Loop over cryostats
     for (unsigned int icstat = 0; icstat < theGeometry->Ncryostats(); ++icstat)
     {
         UIntSet cstatList;
-        
+
         // Loop over TPCs in in this cryostat
         for (unsigned int itpc1 = 0; itpc1 < theGeometry->NTPC(icstat); ++itpc1)
         {
             if (cstatList.end() != cstatList.find(itpc1))
                 continue;
-            
+
             // Use this TPC to seed a drift volume
             const geo::TPCGeo &theTpc1(theGeometry->TPC(itpc1, icstat));
             cstatList.insert(itpc1);
-            
+
             // ATTN: In dual phase scenario propagate the W->U and Y->V mapping and set wire angle for remaining view to epsilon to
             // avoid identical wire angles clashes (dual phase W and Y wires are horizontal and vertical).  Inside LArSoft the
             // WireAngleToVertical function returns the wire angle to the positive Z axis, but Pandora expects to receive the wire
@@ -257,31 +257,31 @@ void LArPandoraGeometry::LoadGeometry(LArDriftVolumeList &driftVolumeList)
             const float wireAngleV(0.5f * M_PI - theGeometry->WireAngleToVertical(targetViewV, itpc1, icstat));
             const float wireAngleW((nWirePlanes < 3) ? std::numeric_limits<float>::epsilon() : (useYPlane) ? (std::fabs(0.5f * M_PI - theGeometry->WireAngleToVertical(geo::kY, itpc1, icstat))) :
                                    (0.5f * M_PI - theGeometry->WireAngleToVertical(geo::kW, itpc1, icstat)));
-            
+
             double localCoord1[3] = {0., 0., 0.};
             double worldCoord1[3] = {0., 0., 0.};
             theTpc1.LocalToWorld(localCoord1, worldCoord1);
-            
+
             const double min1(worldCoord1[0] - 0.5 * theTpc1.ActiveHalfWidth());
             const double max1(worldCoord1[0] + 0.5 * theTpc1.ActiveHalfWidth());
-            
+
             float driftMinX(worldCoord1[0] - theTpc1.ActiveHalfWidth());
             float driftMaxX(worldCoord1[0] + theTpc1.ActiveHalfWidth());
             float driftMinY(worldCoord1[1] - theTpc1.ActiveHalfHeight());
             float driftMaxY(worldCoord1[1] + theTpc1.ActiveHalfHeight());
             float driftMinZ(worldCoord1[2] - 0.5f * theTpc1.ActiveLength());
             float driftMaxZ(worldCoord1[2] + 0.5f * theTpc1.ActiveLength());
-            
+
             const bool isPositiveDrift(theTpc1.DriftDirection() == geo::kPosX);
-            
+
             UIntSet tpcList;
             tpcList.insert(itpc1);
-            
+
             if (isDualPhase)
             {
                 LArDaughterDriftVolumeList tpcVolumeList;
                 tpcVolumeList.push_back(LArDaughterDriftVolume(icstat, itpc1));
-                
+
                 driftVolumeList.push_back(LArDriftVolume(driftVolumeList.size(), isPositiveDrift,
                     wirePitchU, wirePitchV, wirePitchW, wireAngleU, wireAngleV, wireAngleW,
                     0.5f * (driftMaxX + driftMinX), 0.5f * (driftMaxY + driftMinY), 0.5f * (driftMaxZ + driftMinZ),
@@ -294,12 +294,12 @@ void LArPandoraGeometry::LoadGeometry(LArDriftVolumeList &driftVolumeList)
             {
                 if (cstatList.end() != cstatList.find(itpc2))
                     continue;
-                
+
                 const geo::TPCGeo &theTpc2(theGeometry->TPC(itpc2, icstat));
-                
+
                 if (theTpc1.DriftDirection() != theTpc2.DriftDirection())
                     continue;
-                
+
                 // ATTN: In dual phase scenario propagate the W->U and Y->V mapping as described above.
                 const geo::View_t pandoraUView(isDualPhase ? geo::kW : geo::kU);
                 const geo::View_t pandoraVView(isDualPhase ? geo::kY : geo::kV);
@@ -307,59 +307,59 @@ void LArPandoraGeometry::LoadGeometry(LArDriftVolumeList &driftVolumeList)
                 const float dThetaV(theGeometry->WireAngleToVertical(pandoraVView, itpc1, icstat) - theGeometry->WireAngleToVertical(pandoraVView, itpc2, icstat));
                 const float dThetaW((nWirePlanes < 3) ? std::numeric_limits<float>::epsilon() : (useYPlane) ? (theGeometry->WireAngleToVertical(geo::kY, itpc1, icstat) - theGeometry->WireAngleToVertical(geo::kY, itpc2, icstat)) :
                                     (theGeometry->WireAngleToVertical(geo::kW, itpc1, icstat) - theGeometry->WireAngleToVertical(geo::kW, itpc2, icstat)));
-                
+
                 if (dThetaU > maxDeltaTheta || dThetaV > maxDeltaTheta || dThetaW > maxDeltaTheta)
                     continue;
-                
+
                 double localCoord2[3] = {0., 0., 0.};
                 double worldCoord2[3] = {0., 0., 0.};
                 theTpc2.LocalToWorld(localCoord2, worldCoord2);
-                
+
                 const double min2(worldCoord2[0] - 0.5 * theTpc2.ActiveHalfWidth());
                 const double max2(worldCoord2[0] + 0.5 * theTpc2.ActiveHalfWidth());
-                
+
                 if ((min2 > max1) || (min1 > max2))
                     continue;
-                
+
                 cstatList.insert(itpc2);
                 tpcList.insert(itpc2);
-                
+
                 const float driftMinX2(worldCoord2[0] - theTpc2.ActiveHalfWidth());
                 const float driftMaxX2(worldCoord2[0] + theTpc2.ActiveHalfWidth());
                 const float driftMinY2(worldCoord2[1] - theTpc2.ActiveHalfHeight());
                 const float driftMaxY2(worldCoord2[1] + theTpc2.ActiveHalfHeight());
                 const float driftMinZ2(worldCoord2[2] - 0.5f * theTpc2.ActiveLength());
                 const float driftMaxZ2(worldCoord2[2] + 0.5f * theTpc2.ActiveLength());
-                
+
                 driftMinX = std::min(driftMinX, driftMinX2);
                 driftMaxX = std::max(driftMaxX, driftMaxX2);
                 driftMinY = std::min(driftMinY, driftMinY2);
                 driftMaxY = std::max(driftMaxY, driftMaxY2);
                 driftMinZ = std::min(driftMinZ, driftMinZ2);
                 driftMaxZ = std::max(driftMaxZ, driftMaxZ2);
-                
+
                 if (isDualPhase)
                 {
                     LArDaughterDriftVolumeList tpcVolumeList;
                     tpcVolumeList.push_back(LArDaughterDriftVolume(icstat, itpc2));
-                    
+
                     driftVolumeList.push_back(LArDriftVolume(driftVolumeList.size(), isPositiveDrift,
                         wirePitchU, wirePitchV, wirePitchW, wireAngleU, wireAngleV, wireAngleW,
                         0.5f * (driftMaxX2 + driftMinX2), 0.5f * (driftMaxY2 + driftMinY2), 0.5f * (driftMaxZ2 + driftMinZ2),
                         (driftMaxX2 - driftMinX2), (driftMaxY2 - driftMinY2), (driftMaxZ2 - driftMinZ2),
                         (wirePitchU + wirePitchV + wirePitchW + 0.1f), tpcVolumeList));
                 }
-                
+
             }
-            
+
             // Collate the tpc volumes in this drift volume
             LArDaughterDriftVolumeList tpcVolumeList;
-            
+
             for(const unsigned int itpc : tpcList)
             {
                 tpcVolumeList.push_back(LArDaughterDriftVolume(icstat, itpc));
             }
-            
+
             // Create new daughter drift volume (volume ID = 0 to N-1)
             if (!isDualPhase)
                 driftVolumeList.push_back(LArDriftVolume(driftVolumeList.size(), isPositiveDrift,

--- a/larpandora/LArPandoraInterface/LArPandoraGeometry.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraGeometry.cxx
@@ -37,7 +37,6 @@ void LArPandoraGeometry::LoadDetectorGaps(LArDetectorGapList &listOfGaps)
     {
         const LArDriftVolume &driftVolume1 = *iter1;
         
-        
         for (LArDriftVolumeList::const_iterator iter2 = iter1, iterEnd2 = driftVolumeList.end(); iter2 != iterEnd2; ++iter2)
         {
             const LArDriftVolume &driftVolume2 = *iter2;
@@ -45,7 +44,7 @@ void LArPandoraGeometry::LoadDetectorGaps(LArDetectorGapList &listOfGaps)
             if (driftVolume1.GetVolumeID() == driftVolume2.GetVolumeID())
                 continue;
 
-            const float maxDisplacement(30.f); // TODO: 30cm should be fine, but can we do better than a hard-coded number here?
+            const float maxDisplacement(LArDetectorGap::GetMaxGapSize());
 
             const float deltaX(std::fabs(driftVolume1.GetCenterX() - driftVolume2.GetCenterX()));
             const float deltaY(std::fabs(driftVolume1.GetCenterY() - driftVolume2.GetCenterY()));
@@ -63,25 +62,22 @@ void LArPandoraGeometry::LoadDetectorGaps(LArDetectorGapList &listOfGaps)
                 continue;
             
             const float X1((driftVolume1.GetCenterX() < driftVolume2.GetCenterX()) ? (driftVolume1.GetCenterX() + 0.5f * driftVolume1.GetWidthX()) :
-                           (driftVolume2.GetCenterX() + 0.5f * driftVolume2.GetWidthX()));
+                (driftVolume2.GetCenterX() + 0.5f * driftVolume2.GetWidthX()));
             const float X2((driftVolume1.GetCenterX() > driftVolume2.GetCenterX()) ? (driftVolume1.GetCenterX() - 0.5f * driftVolume1.GetWidthX()) :
-                           (driftVolume2.GetCenterX() - 0.5f * driftVolume2.GetWidthX()));
+                (driftVolume2.GetCenterX() - 0.5f * driftVolume2.GetWidthX()));
             const float Y1(std::min((driftVolume1.GetCenterY() - 0.5f * driftVolume1.GetWidthY()),
-                                    (driftVolume2.GetCenterY() - 0.5f * driftVolume2.GetWidthY())));
+                (driftVolume2.GetCenterY() - 0.5f * driftVolume2.GetWidthY())));
             const float Y2(std::max((driftVolume1.GetCenterY() + 0.5f * driftVolume1.GetWidthY()),
-                                    (driftVolume2.GetCenterY() + 0.5f * driftVolume2.GetWidthY())));
+                (driftVolume2.GetCenterY() + 0.5f * driftVolume2.GetWidthY())));
             const float Z1(std::min((driftVolume1.GetCenterZ() - 0.5f * driftVolume1.GetWidthZ()),
-                                    (driftVolume2.GetCenterZ() - 0.5f * driftVolume2.GetWidthZ())));
+                (driftVolume2.GetCenterZ() - 0.5f * driftVolume2.GetWidthZ())));
             const float Z2(std::max((driftVolume1.GetCenterZ() + 0.5f * driftVolume1.GetWidthZ()),
-                                    (driftVolume2.GetCenterZ() + 0.5f * driftVolume2.GetWidthZ())));
+                (driftVolume2.GetCenterZ() + 0.5f * driftVolume2.GetWidthZ())));
             
             if (isDualPhase && (std::fabs(gapY) > maxDisplacement || std::fabs(gapZ) > maxDisplacement))
-            {
-                listOfGaps.push_back(LArDetectorGap(X1, Y1 + widthY, Z1 + widthY, X2, Y2 - widthY, Z2 - widthZ));
-                continue;
-            }
+                listOfGaps.push_back(LArDetectorGap(X1, Y1 + widthY, Z1 + widthZ, X2, Y2 - widthY, Z2 - widthZ));
 
-            if (!isDualPhase)
+            else if (!isDualPhase)
                 listOfGaps.push_back(LArDetectorGap(X1, Y1, Z1, X2, Y2, Z2));
         }
     }
@@ -287,12 +283,12 @@ void LArPandoraGeometry::LoadGeometry(LArDriftVolumeList &driftVolumeList)
                 tpcVolumeList.push_back(LArDaughterDriftVolume(icstat, itpc1));
                 
                 driftVolumeList.push_back(LArDriftVolume(driftVolumeList.size(), isPositiveDrift,
-                                                         wirePitchU, wirePitchV, wirePitchW, wireAngleU, wireAngleV, wireAngleW,
-                                                         0.5f * (driftMaxX + driftMinX), 0.5f * (driftMaxY + driftMinY), 0.5f * (driftMaxZ + driftMinZ),
-                                                         (driftMaxX - driftMinX), (driftMaxY - driftMinY), (driftMaxZ - driftMinZ),
-                                                         (wirePitchU + wirePitchV + wirePitchW + 0.1f), tpcVolumeList));
-                
+                    wirePitchU, wirePitchV, wirePitchW, wireAngleU, wireAngleV, wireAngleW,
+                    0.5f * (driftMaxX + driftMinX), 0.5f * (driftMaxY + driftMinY), 0.5f * (driftMaxZ + driftMinZ),
+                    (driftMaxX - driftMinX), (driftMaxY - driftMinY), (driftMaxZ - driftMinZ),
+                    (wirePitchU + wirePitchV + wirePitchW + 0.1f), tpcVolumeList));
             }
+
             // Now identify the other TPCs associated with this drift volume
             for (unsigned int itpc2 = itpc1+1; itpc2 < theGeometry->NTPC(icstat); ++itpc2)
             {
@@ -328,12 +324,12 @@ void LArPandoraGeometry::LoadGeometry(LArDriftVolumeList &driftVolumeList)
                 cstatList.insert(itpc2);
                 tpcList.insert(itpc2);
                 
-                float driftMinX2(worldCoord2[0] - theTpc2.ActiveHalfWidth());
-                float driftMaxX2(worldCoord2[0] + theTpc2.ActiveHalfWidth());
-                float driftMinY2(worldCoord2[1] - theTpc2.ActiveHalfHeight());
-                float driftMaxY2(worldCoord2[1] + theTpc2.ActiveHalfHeight());
-                float driftMinZ2(worldCoord2[2] - 0.5f * theTpc2.ActiveLength());
-                float driftMaxZ2(worldCoord2[2] + 0.5f * theTpc2.ActiveLength());
+                const float driftMinX2(worldCoord2[0] - theTpc2.ActiveHalfWidth());
+                const float driftMaxX2(worldCoord2[0] + theTpc2.ActiveHalfWidth());
+                const float driftMinY2(worldCoord2[1] - theTpc2.ActiveHalfHeight());
+                const float driftMaxY2(worldCoord2[1] + theTpc2.ActiveHalfHeight());
+                const float driftMinZ2(worldCoord2[2] - 0.5f * theTpc2.ActiveLength());
+                const float driftMaxZ2(worldCoord2[2] + 0.5f * theTpc2.ActiveLength());
                 
                 driftMinX = std::min(driftMinX, driftMinX2);
                 driftMaxX = std::max(driftMaxX, driftMaxX2);
@@ -348,10 +344,10 @@ void LArPandoraGeometry::LoadGeometry(LArDriftVolumeList &driftVolumeList)
                     tpcVolumeList.push_back(LArDaughterDriftVolume(icstat, itpc2));
                     
                     driftVolumeList.push_back(LArDriftVolume(driftVolumeList.size(), isPositiveDrift,
-                                                             wirePitchU, wirePitchV, wirePitchW, wireAngleU, wireAngleV, wireAngleW,
-                                                             0.5f * (driftMaxX2 + driftMinX2), 0.5f * (driftMaxY2 + driftMinY2), 0.5f * (driftMaxZ2 + driftMinZ2),
-                                                             (driftMaxX2 - driftMinX2), (driftMaxY2 - driftMinY2), (driftMaxZ2 - driftMinZ2),
-                                                             (wirePitchU + wirePitchV + wirePitchW + 0.1f), tpcVolumeList));
+                        wirePitchU, wirePitchV, wirePitchW, wireAngleU, wireAngleV, wireAngleW,
+                        0.5f * (driftMaxX2 + driftMinX2), 0.5f * (driftMaxY2 + driftMinY2), 0.5f * (driftMaxZ2 + driftMinZ2),
+                        (driftMaxX2 - driftMinX2), (driftMaxY2 - driftMinY2), (driftMaxZ2 - driftMinZ2),
+                        (wirePitchU + wirePitchV + wirePitchW + 0.1f), tpcVolumeList));
                 }
                 
             }
@@ -367,10 +363,10 @@ void LArPandoraGeometry::LoadGeometry(LArDriftVolumeList &driftVolumeList)
             // Create new daughter drift volume (volume ID = 0 to N-1)
             if (!isDualPhase)
                 driftVolumeList.push_back(LArDriftVolume(driftVolumeList.size(), isPositiveDrift,
-                                                         wirePitchU, wirePitchV, wirePitchW, wireAngleU, wireAngleV, wireAngleW,
-                                                         0.5f * (driftMaxX + driftMinX), 0.5f * (driftMaxY + driftMinY), 0.5f * (driftMaxZ + driftMinZ),
-                                                         (driftMaxX - driftMinX), (driftMaxY - driftMinY), (driftMaxZ - driftMinZ),
-                                                         (wirePitchU + wirePitchV + wirePitchW + 0.1f), tpcVolumeList));
+                    wirePitchU, wirePitchV, wirePitchW, wireAngleU, wireAngleV, wireAngleW,
+                    0.5f * (driftMaxX + driftMinX), 0.5f * (driftMaxY + driftMinY), 0.5f * (driftMaxZ + driftMinZ),
+                    (driftMaxX - driftMinX), (driftMaxY - driftMinY), (driftMaxZ - driftMinZ),
+                    (wirePitchU + wirePitchV + wirePitchW + 0.1f), tpcVolumeList));
         }
     }
 

--- a/larpandora/LArPandoraInterface/LArPandoraGeometry.h
+++ b/larpandora/LArPandoraInterface/LArPandoraGeometry.h
@@ -63,6 +63,11 @@ public:
      */
     float GetZ2() const;
 
+    /**
+     *  @brief Get maximum gap size
+     */
+    static float GetMaxGapSize();
+
 private:
     float   m_x1;
     float   m_y1;
@@ -70,6 +75,7 @@ private:
     float   m_x2;
     float   m_y2;
     float   m_z2;
+    float   m_maxGapSize;
 };
 
 typedef std::vector<LArDetectorGap> LArDetectorGapList;
@@ -379,6 +385,13 @@ inline float LArDetectorGap::GetY2() const
 inline float LArDetectorGap::GetZ2() const
 {
     return m_z2;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline float LArDetectorGap::GetMaxGapSize()
+{
+    return 30.f; // TODO: 30cm should be fine but can we do better than a hard-coded number here?
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandora/LArPandoraInterface/LArPandoraInput.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraInput.cxx
@@ -215,17 +215,53 @@ void LArPandoraInput::CreatePandoraLArTPCs(const Settings &settings, const LArDr
 
 void LArPandoraInput::CreatePandoraDetectorGaps(const Settings &settings, const LArDriftVolumeList &driftVolumeList, const LArDetectorGapList &listOfGaps)
 {
+    //ATTN - Unlike SP, DP detector gaps are not in the drift direction 
+    art::ServiceHandle<geo::Geometry const> theGeometry;
+    const bool isDualPhase(theGeometry->MaxPlanes() == 2);
+    
     mf::LogDebug("LArPandora") << " *** LArPandoraInput::CreatePandoraDetectorGaps(...) *** " << std::endl;
-
+    
     if (!settings.m_pPrimaryPandora)
         throw cet::exception("LArPandora") << "CreatePandoraDetectorGaps - primary Pandora instance does not exist ";
-
+    
     const pandora::Pandora *pPandora(settings.m_pPrimaryPandora);
-
+    
     for (const LArDetectorGap &gap : listOfGaps)
     {
         PandoraApi::Geometry::LineGap::Parameters parameters;
-
+        
+        if (isDualPhase)
+        {
+            const float gapSizeY (std::fabs(gap.GetY2() - gap.GetY1())); //Could have chosen Z here, resulting in switching Y<->Z and U<->V in the try{...} block below
+            
+            const float maxGapSize (30.); //Match the maxDisplacement variable hard-coded value in LArPandoraGeometry
+             
+            try
+            {
+                parameters.m_lineGapType = ((gapSizeY > maxGapSize) ? pandora::TPC_WIRE_GAP_VIEW_U : pandora::TPC_WIRE_GAP_VIEW_V); //If gapSizeY is too large then the gap is in Z, therefore should be in kU (i.e. kZ)
+                parameters.m_lineStartX = gap.GetX2();
+                parameters.m_lineEndX = gap.GetX1();
+                parameters.m_lineStartZ = ((gapSizeY > maxGapSize) ? gap.GetZ1() : gap.GetY1());
+                parameters.m_lineEndZ = ((gapSizeY > maxGapSize) ? gap.GetZ2() : gap.GetY2());
+            }
+            
+            catch (const pandora::StatusCodeException &)
+            {
+                mf::LogWarning("LArPandora") << "CreatePandoraDetectorGaps - invalid line gap parameter provided, all assigned values must be finite, line gap omitted " << std::endl;
+                continue;
+            }
+            try
+            {
+                PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraApi::Geometry::LineGap::Create(*pPandora, parameters));
+            }
+            catch (const pandora::StatusCodeException &)
+            {
+                mf::LogWarning("LArPandora") << "CreatePandoraDetectorGaps - unable to create line gap, insufficient or invalid information supplied " << std::endl;
+                continue;
+            }
+            continue; //No drift gaps in DP
+        }
+        
         try
         {
             parameters.m_lineGapType = pandora::TPC_DRIFT_GAP;
@@ -250,66 +286,6 @@ void LArPandoraInput::CreatePandoraDetectorGaps(const Settings &settings, const 
             continue;
         }
     }
-
-    //Create CRP gaps for DP
-    art::ServiceHandle<geo::Geometry const> theGeometry;
-    const bool isDualPhase(theGeometry->MaxPlanes() == 2);
-    const int nCRPs(theGeometry->NTPC());
-    if(!isDualPhase || nCRPs!=4) return; //only add CRP gaps if ProtoDUNE DP
-
-    const double crpGapLowerZ_y(-0.64875), crpGapUpperZ_y(0.66375);
-    const double crpGapLowerZ_z(299.851), crpGapUpperZ_z(301.164);
-
-    for (const LArDriftVolume &driftVolume : driftVolumeList)
-    {
-
-	    PandoraApi::Geometry::LineGap::Parameters parameters;
-	    try
-	    {
-	      parameters.m_lineGapType = pandora::TPC_WIRE_GAP_VIEW_U;
-	      //parameters.m_lineStartX = -std::numeric_limits<float>::max();
-	      //parameters.m_lineEndX = std::numeric_limits<float>::max();
-	      parameters.m_lineStartX = driftVolume.GetCenterX() - 0.5f * driftVolume.GetWidthX();
-	      parameters.m_lineEndX = driftVolume.GetCenterX() + 0.5f * driftVolume.GetWidthX();
-	      parameters.m_lineStartZ = crpGapLowerZ_z;
-	      parameters.m_lineEndZ = crpGapUpperZ_z;
-	    }
-	    catch (const pandora::StatusCodeException &)
-	    {
-	      mf::LogWarning("LArPandora") << "CreatePandoraDetectorGaps - invalid line gap parameter provided, all assigned values must be finite, line gap omitted " << std::endl;
-	    }
-	    try
-	    {
-	      PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraApi::Geometry::LineGap::Create(*pPandora, parameters));
-	    }
-	    catch (const pandora::StatusCodeException &)
-	    {
-	      mf::LogWarning("LArPandora") << "CreatePandoraDetectorGaps - unable to create line gap, insufficient or invalid information supplied " << std::endl;
-	    }
-
-	    try
-	    {
-	      parameters.m_lineGapType = pandora::TPC_WIRE_GAP_VIEW_V;
-	      //parameters.m_lineStartX = -std::numeric_limits<float>::max();
-	      //parameters.m_lineEndX = std::numeric_limits<float>::max();
-	      parameters.m_lineStartX = driftVolume.GetCenterX() - 0.5f * driftVolume.GetWidthX();
-	      parameters.m_lineEndX = driftVolume.GetCenterX() + 0.5f * driftVolume.GetWidthX();
-	      parameters.m_lineStartZ = crpGapLowerZ_y;
-	      parameters.m_lineEndZ = crpGapUpperZ_y;
-	    }
-	    catch (const pandora::StatusCodeException &)
-	    {
-	      mf::LogWarning("LArPandora") << "CreatePandoraDetectorGaps - invalid line gap parameter provided, all assigned values must be finite, line gap omitted " << std::endl;
-	    }
-	    try
-	    {
-	      PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraApi::Geometry::LineGap::Create(*pPandora, parameters));
-	    }
-	    catch (const pandora::StatusCodeException &)
-	    {
-	      mf::LogWarning("LArPandora") << "CreatePandoraDetectorGaps - unable to create line gap, insufficient or invalid information supplied " << std::endl;
-	    }
-       }
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -317,107 +293,124 @@ void LArPandoraInput::CreatePandoraDetectorGaps(const Settings &settings, const 
 void LArPandoraInput::CreatePandoraReadoutGaps(const Settings &settings, const LArDriftVolumeMap &driftVolumeMap)
 {
     mf::LogDebug("LArPandora") << " *** LArPandoraInput::CreatePandoraReadoutGaps(...) *** " << std::endl;
-
+    
     if (!settings.m_pPrimaryPandora)
         throw cet::exception("LArPandora") << "CreatePandoraReadoutGaps - primary Pandora instance does not exist ";
-
+    
     const pandora::Pandora *pPandora(settings.m_pPrimaryPandora);
-
+    
     art::ServiceHandle<geo::Geometry const> theGeometry;
     const lariov::ChannelStatusProvider &channelStatus(art::ServiceHandle<lariov::ChannelStatusService const>()->GetProvider());
+    
+    const bool isDualPhase(theGeometry->MaxPlanes() == 2);
 
     for (unsigned int icstat = 0; icstat < theGeometry->Ncryostats(); ++icstat)
     {
         for (unsigned int itpc = 0; itpc < theGeometry->NTPC(icstat); ++itpc)
         {
             const geo::TPCGeo &TPC(theGeometry->TPC(itpc));
-
+            
             for (unsigned int iplane = 0; iplane < TPC.Nplanes(); ++iplane)
             {
                 const geo::PlaneGeo &plane(TPC.Plane(iplane));
                 const float halfWirePitch(0.5f * theGeometry->WirePitch(plane.View()));
                 const unsigned int nWires(theGeometry->Nwires(plane.ID()));
-
+                
                 int firstBadWire(-1), lastBadWire(-1);
-
+                
                 for (unsigned int iwire = 0; iwire < nWires; ++iwire)
                 {
                     const raw::ChannelID_t channel(theGeometry->PlaneWireToChannel(iplane, iwire, itpc, icstat));
                     const bool isBadChannel(channelStatus.IsBad(channel));
                     const bool isLastWire(nWires == (iwire + 1));
-
+                    
                     if (isBadChannel && (firstBadWire < 0))
                         firstBadWire = iwire;
-
+                    
                     if (isBadChannel || isLastWire)
                         lastBadWire = iwire;
-
+                    
                     if (isBadChannel && !isLastWire)
                         continue;
 
                     if ((firstBadWire < 0) || (lastBadWire < 0))
                         continue;
-
+                    
                     double firstXYZ[3], lastXYZ[3];
                     theGeometry->Cryostat(icstat).TPC(itpc).Plane(iplane).Wire(firstBadWire).GetCenter(firstXYZ);
                     theGeometry->Cryostat(icstat).TPC(itpc).Plane(iplane).Wire(lastBadWire).GetCenter(lastXYZ);
-
+                    
                     firstBadWire = -1; lastBadWire = -1;
-
+                    
                     PandoraApi::Geometry::LineGap::Parameters parameters;
-
+                    
                     try
                     {
                         parameters.m_lineStartX = -std::numeric_limits<float>::max();
                         parameters.m_lineEndX = std::numeric_limits<float>::max();
-
+                        
                         const unsigned int volumeId(LArPandoraGeometry::GetVolumeID(driftVolumeMap, icstat, itpc));
                         LArDriftVolumeMap::const_iterator volumeIter(driftVolumeMap.find(volumeId));
-
+                        
                         if (driftVolumeMap.end() != volumeIter)
                         {
                             parameters.m_lineStartX = volumeIter->second.GetCenterX() - 0.5f * volumeIter->second.GetWidthX();
                             parameters.m_lineEndX = volumeIter->second.GetCenterX() + 0.5f * volumeIter->second.GetWidthX();
                         }
-
+                        
                         const geo::View_t iview = (geo::View_t)plane.View();
                         const geo::View_t pandoraView(LArPandoraGeometry::GetGlobalView(icstat, itpc, iview));
-
-                        if (pandoraView == geo::kW || pandoraView == geo::kZ)
+                        
+                        if(isDualPhase)
                         {
-                            const float firstW(firstXYZ[2]);
-                            const float lastW(lastXYZ[2]);
-
-                            parameters.m_lineGapType = pandora::TPC_WIRE_GAP_VIEW_U;
-                            parameters.m_lineStartZ = std::min(firstW, lastW) - halfWirePitch;
-                            parameters.m_lineEndZ = std::max(firstW, lastW) + halfWirePitch;
+                            if (pandoraView == geo::kW || pandoraView == geo::kZ)
+                            {
+                                const float firstW(firstXYZ[2]);
+                                const float lastW(lastXYZ[2]);
+                                
+                                parameters.m_lineGapType = pandora::TPC_WIRE_GAP_VIEW_U;
+                                parameters.m_lineStartZ = std::min(firstW, lastW) - halfWirePitch;
+                                parameters.m_lineEndZ = std::max(firstW, lastW) + halfWirePitch;
+                            }
+                            else if (pandoraView == geo::kY)
+                            {
+                                const float firstY(firstXYZ[1]);
+                                const float lastY(lastXYZ[1]);
+                                
+                                parameters.m_lineGapType = pandora::TPC_WIRE_GAP_VIEW_V;
+                                parameters.m_lineStartZ = std::min(firstY, lastY) - halfWirePitch;
+                                parameters.m_lineEndZ = std::max(firstY, lastY) + halfWirePitch;
+                            }
                         }
-                        if (pandoraView == geo::kY)
+                        else 
                         {
-                            const float firstW(firstXYZ[1]);
-                            const float lastW(lastXYZ[1]);
-
-                            parameters.m_lineGapType = pandora::TPC_WIRE_GAP_VIEW_V;
-                            parameters.m_lineStartZ = std::min(firstW, lastW) - halfWirePitch;
-                            parameters.m_lineEndZ = std::max(firstW, lastW) + halfWirePitch;
-                        }
-                        else if (pandoraView == geo::kU)
-                        {
-                            const float firstU(pPandora->GetPlugins()->GetLArTransformationPlugin()->YZtoU(firstXYZ[1], firstXYZ[2]));
-                            const float lastU(pPandora->GetPlugins()->GetLArTransformationPlugin()->YZtoU(lastXYZ[1], lastXYZ[2]));
-
-                            parameters.m_lineGapType = pandora::TPC_WIRE_GAP_VIEW_U;
-                            parameters.m_lineStartZ = std::min(firstU, lastU) - halfWirePitch;
-                            parameters.m_lineEndZ = std::max(firstU, lastU) + halfWirePitch;
-                        }
-                        else if (pandoraView == geo::kV)
-                        {
-                            const float firstV(pPandora->GetPlugins()->GetLArTransformationPlugin()->YZtoV(firstXYZ[1], firstXYZ[2]));
-                            const float lastV(pPandora->GetPlugins()->GetLArTransformationPlugin()->YZtoV(lastXYZ[1], lastXYZ[2]));
-
-                            parameters.m_lineGapType = pandora::TPC_WIRE_GAP_VIEW_V;
-                            parameters.m_lineStartZ = std::min(firstV, lastV) - halfWirePitch;
-                            parameters.m_lineEndZ = std::max(firstV, lastV) + halfWirePitch;
+                            if (pandoraView == geo::kW || pandoraView == geo::kY)
+                            {
+                                const float firstW(firstXYZ[2]);
+                                const float lastW(lastXYZ[2]);
+                                
+                                parameters.m_lineGapType = pandora::TPC_WIRE_GAP_VIEW_W;
+                                parameters.m_lineStartZ = std::min(firstW, lastW) - halfWirePitch;
+                                parameters.m_lineEndZ = std::max(firstW, lastW) + halfWirePitch;
+                            }
+                            else if (pandoraView == geo::kU)
+                            {
+                                const float firstU(pPandora->GetPlugins()->GetLArTransformationPlugin()->YZtoU(firstXYZ[1], firstXYZ[2]));
+                                const float lastU(pPandora->GetPlugins()->GetLArTransformationPlugin()->YZtoU(lastXYZ[1], lastXYZ[2]));
+                                
+                                parameters.m_lineGapType = pandora::TPC_WIRE_GAP_VIEW_U;
+                                parameters.m_lineStartZ = std::min(firstU, lastU) - halfWirePitch;
+                                parameters.m_lineEndZ = std::max(firstU, lastU) + halfWirePitch;
+                            }
+                            else if (pandoraView == geo::kV)
+                            {
+                                const float firstV(pPandora->GetPlugins()->GetLArTransformationPlugin()->YZtoV(firstXYZ[1], firstXYZ[2]));
+                                const float lastV(pPandora->GetPlugins()->GetLArTransformationPlugin()->YZtoV(lastXYZ[1], lastXYZ[2]));
+                                
+                                parameters.m_lineGapType = pandora::TPC_WIRE_GAP_VIEW_V;
+                                parameters.m_lineStartZ = std::min(firstV, lastV) - halfWirePitch;
+                                parameters.m_lineEndZ = std::max(firstV, lastV) + halfWirePitch;
+                            }
                         }
                     }
                     catch (const pandora::StatusCodeException &)
@@ -425,7 +418,7 @@ void LArPandoraInput::CreatePandoraReadoutGaps(const Settings &settings, const L
                         mf::LogWarning("LArPandora") << "CreatePandoraReadoutGaps - invalid line gap parameter provided, all assigned values must be finite, line gap omitted " << std::endl;
                         continue;
                     }
-
+                    
                     try
                     {
                         PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraApi::Geometry::LineGap::Create(*pPandora, parameters));

--- a/larpandora/LArPandoraInterface/LArPandoraInput.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraInput.cxx
@@ -250,6 +250,57 @@ void LArPandoraInput::CreatePandoraDetectorGaps(const Settings &settings, const 
             continue;
         }
     }
+
+    //Create CRP gaps for DP
+    const bool isDualPhase(theGeometry->MaxPlanes() == 2);
+    if(!isDualPhase) return;
+
+    const double crpGapLowerZ_y(-0.64875), crpGapUpperZ_y(0.66375);
+    const double crpGapLowerZ_z(299.851), crpGapUpperZ_z(301.164);
+
+    PandoraApi::Geometry::LineGap::Parameters parameters;
+    try
+    {
+      parameters.m_lineGapType = pandora::TPC_WIRE_GAP_VIEW_U;
+      parameters.m_lineStartX = -std::numeric_limits<float>::max();
+      parameters.m_lineEndX = std::numeric_limits<float>::max();
+      parameters.m_lineStartZ = crpGapLowerZ_z;
+      parameters.m_lineEndZ = crpGapUpperZ_z;
+    }
+    catch (const pandora::StatusCodeException &)
+    {
+      mf::LogWarning("LArPandora") << "CreatePandoraDetectorGaps - invalid line gap parameter provided, all assigned values must be finite, line gap omitted " << std::endl;
+    }
+    try
+    {
+      PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraApi::Geometry::LineGap::Create(*pPandora, parameters));
+    }
+    catch (const pandora::StatusCodeException &)
+    {
+      mf::LogWarning("LArPandora") << "CreatePandoraDetectorGaps - unable to create line gap, insufficient or invalid information supplied " << std::endl;
+    }
+
+    try
+    {
+      parameters.m_lineGapType = pandora::TPC_WIRE_GAP_VIEW_V;
+      parameters.m_lineStartX = -std::numeric_limits<float>::max();
+      parameters.m_lineEndX = std::numeric_limits<float>::max();
+      parameters.m_lineStartZ = crpGapLowerZ_y;
+      parameters.m_lineEndZ = crpGapUpperZ_y;
+    }
+    catch (const pandora::StatusCodeException &)
+    {
+      mf::LogWarning("LArPandora") << "CreatePandoraDetectorGaps - invalid line gap parameter provided, all assigned values must be finite, line gap omitted " << std::endl;
+    }
+    try
+    {
+      PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraApi::Geometry::LineGap::Create(*pPandora, parameters));
+    }
+    catch (const pandora::StatusCodeException &)
+    {
+      mf::LogWarning("LArPandora") << "CreatePandoraDetectorGaps - unable to create line gap, insufficient or invalid information supplied " << std::endl;
+    }
+
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -378,56 +429,6 @@ void LArPandoraInput::CreatePandoraReadoutGaps(const Settings &settings, const L
                 }
             }
         }
-    }
-
-    //Create CRP gaps for DP
-    const bool isDualPhase(theGeometry->MaxPlanes() == 2);
-    if(!isDualPhase) return;
-
-    const double crpGapLowerZ_y(-0.64875), crpGapUpperZ_y(0.66375);
-    const double crpGapLowerZ_z(299.851), crpGapUpperZ_z(301.164);
-
-    PandoraApi::Geometry::LineGap::Parameters parameters;
-    try
-    {
-      parameters.m_lineGapType = pandora::TPC_WIRE_GAP_VIEW_U;
-      parameters.m_lineStartX = -std::numeric_limits<float>::max();
-      parameters.m_lineEndX = std::numeric_limits<float>::max();
-      parameters.m_lineStartZ = crpGapLowerZ_z;
-      parameters.m_lineEndZ = crpGapUpperZ_z;
-    }
-    catch (const pandora::StatusCodeException &)
-    {
-      mf::LogWarning("LArPandora") << "CreatePandoraDetectorGaps - invalid line gap parameter provided, all assigned values must be finite, line gap omitted " << std::endl;
-    }
-    try
-    {
-      PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraApi::Geometry::LineGap::Create(*pPandora, parameters));
-    }
-    catch (const pandora::StatusCodeException &)
-    {
-      mf::LogWarning("LArPandora") << "CreatePandoraDetectorGaps - unable to create line gap, insufficient or invalid information supplied " << std::endl;
-    }
-
-    try
-    {
-      parameters.m_lineGapType = pandora::TPC_WIRE_GAP_VIEW_V;
-      parameters.m_lineStartX = -std::numeric_limits<float>::max();
-      parameters.m_lineEndX = std::numeric_limits<float>::max();
-      parameters.m_lineStartZ = crpGapLowerZ_y;
-      parameters.m_lineEndZ = crpGapUpperZ_y;
-    }
-    catch (const pandora::StatusCodeException &)
-    {
-      mf::LogWarning("LArPandora") << "CreatePandoraDetectorGaps - invalid line gap parameter provided, all assigned values must be finite, line gap omitted " << std::endl;
-    }
-    try
-    {
-      PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraApi::Geometry::LineGap::Create(*pPandora, parameters));
-    }
-    catch (const pandora::StatusCodeException &)
-    {
-      mf::LogWarning("LArPandora") << "CreatePandoraDetectorGaps - unable to create line gap, insufficient or invalid information supplied " << std::endl;
     }
 }
 

--- a/larpandora/LArPandoraInterface/LArPandoraInput.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraInput.cxx
@@ -379,6 +379,56 @@ void LArPandoraInput::CreatePandoraReadoutGaps(const Settings &settings, const L
             }
         }
     }
+
+    //Create CRP gaps for DP
+    const bool isDualPhase(theGeometry->MaxPlanes() == 2);
+    if(!isDualPhase) return;
+
+    const double crpGapLowerZ_y(-0.64875), crpGapUpperZ_y(0.66375);
+    const double crpGapLowerZ_z(299.851), crpGapUpperZ_z(301.164);
+
+    PandoraApi::Geometry::LineGap::Parameters parameters;
+    try
+    {
+      parameters.m_lineGapType = pandora::TPC_WIRE_GAP_VIEW_U;
+      parameters.m_lineStartX = -std::numeric_limits<float>::max();
+      parameters.m_lineEndX = std::numeric_limits<float>::max();
+      parameters.m_lineStartZ = crpGapLowerZ_z;
+      parameters.m_lineEndZ = crpGapUpperZ_z;
+    }
+    catch (const pandora::StatusCodeException &)
+    {
+      mf::LogWarning("LArPandora") << "CreatePandoraDetectorGaps - invalid line gap parameter provided, all assigned values must be finite, line gap omitted " << std::endl;
+    }
+    try
+    {
+      PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraApi::Geometry::LineGap::Create(*pPandora, parameters));
+    }
+    catch (const pandora::StatusCodeException &)
+    {
+      mf::LogWarning("LArPandora") << "CreatePandoraDetectorGaps - unable to create line gap, insufficient or invalid information supplied " << std::endl;
+    }
+
+    try
+    {
+      parameters.m_lineGapType = pandora::TPC_WIRE_GAP_VIEW_V;
+      parameters.m_lineStartX = -std::numeric_limits<float>::max();
+      parameters.m_lineEndX = std::numeric_limits<float>::max();
+      parameters.m_lineStartZ = crpGapLowerZ_y;
+      parameters.m_lineEndZ = crpGapUpperZ_y;
+    }
+    catch (const pandora::StatusCodeException &)
+    {
+      mf::LogWarning("LArPandora") << "CreatePandoraDetectorGaps - invalid line gap parameter provided, all assigned values must be finite, line gap omitted " << std::endl;
+    }
+    try
+    {
+      PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraApi::Geometry::LineGap::Create(*pPandora, parameters));
+    }
+    catch (const pandora::StatusCodeException &)
+    {
+      mf::LogWarning("LArPandora") << "CreatePandoraDetectorGaps - unable to create line gap, insufficient or invalid information supplied " << std::endl;
+    }
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandora/LArPandoraInterface/LArPandoraInput.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraInput.cxx
@@ -276,13 +276,13 @@ void LArPandoraInput::CreatePandoraReadoutGaps(const Settings &settings, const L
             {
                 const geo::PlaneGeo &plane(TPC.Plane(iplane));
                 const float halfWirePitch(0.5f * theGeometry->WirePitch(plane.View()));
-                const unsigned int nWires(theGeometry->Nwires(geo::PlaneID(icstat, itpc, plane.View())));
+                const unsigned int nWires(theGeometry->Nwires(plane.ID()));
 
                 int firstBadWire(-1), lastBadWire(-1);
 
                 for (unsigned int iwire = 0; iwire < nWires; ++iwire)
                 {
-                    const raw::ChannelID_t channel(theGeometry->PlaneWireToChannel(plane.View(), iwire, itpc, icstat));
+                    const raw::ChannelID_t channel(theGeometry->PlaneWireToChannel(iplane, iwire, itpc, icstat));
                     const bool isBadChannel(channelStatus.IsBad(channel));
                     const bool isLastWire(nWires == (iwire + 1));
 
@@ -320,15 +320,24 @@ void LArPandoraInput::CreatePandoraReadoutGaps(const Settings &settings, const L
                             parameters.m_lineEndX = volumeIter->second.GetCenterX() + 0.5f * volumeIter->second.GetWidthX();
                         }
 
-                        const geo::View_t iview = (geo::View_t)iplane;
+                        const geo::View_t iview = (geo::View_t)plane.View();
                         const geo::View_t pandoraView(LArPandoraGeometry::GetGlobalView(icstat, itpc, iview));
 
-                        if (pandoraView == geo::kW || pandoraView == geo::kY)
+                        if (pandoraView == geo::kW || pandoraView == geo::kZ)
                         {
                             const float firstW(firstXYZ[2]);
                             const float lastW(lastXYZ[2]);
 
-                            parameters.m_lineGapType = pandora::TPC_WIRE_GAP_VIEW_W;
+                            parameters.m_lineGapType = pandora::TPC_WIRE_GAP_VIEW_U;
+                            parameters.m_lineStartZ = std::min(firstW, lastW) - halfWirePitch;
+                            parameters.m_lineEndZ = std::max(firstW, lastW) + halfWirePitch;
+                        }
+                        if (pandoraView == geo::kY)
+                        {
+                            const float firstW(firstXYZ[1]);
+                            const float lastW(lastXYZ[1]);
+
+                            parameters.m_lineGapType = pandora::TPC_WIRE_GAP_VIEW_V;
                             parameters.m_lineStartZ = std::min(firstW, lastW) - halfWirePitch;
                             parameters.m_lineEndZ = std::max(firstW, lastW) + halfWirePitch;
                         }

--- a/larpandora/LArPandoraInterface/LArPandoraInput.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraInput.cxx
@@ -260,49 +260,56 @@ void LArPandoraInput::CreatePandoraDetectorGaps(const Settings &settings, const 
     const double crpGapLowerZ_y(-0.64875), crpGapUpperZ_y(0.66375);
     const double crpGapLowerZ_z(299.851), crpGapUpperZ_z(301.164);
 
-    PandoraApi::Geometry::LineGap::Parameters parameters;
-    try
+    for (const LArDriftVolume &driftVolume : driftVolumeList)
     {
-      parameters.m_lineGapType = pandora::TPC_WIRE_GAP_VIEW_U;
-      parameters.m_lineStartX = -std::numeric_limits<float>::max();
-      parameters.m_lineEndX = std::numeric_limits<float>::max();
-      parameters.m_lineStartZ = crpGapLowerZ_z;
-      parameters.m_lineEndZ = crpGapUpperZ_z;
-    }
-    catch (const pandora::StatusCodeException &)
-    {
-      mf::LogWarning("LArPandora") << "CreatePandoraDetectorGaps - invalid line gap parameter provided, all assigned values must be finite, line gap omitted " << std::endl;
-    }
-    try
-    {
-      PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraApi::Geometry::LineGap::Create(*pPandora, parameters));
-    }
-    catch (const pandora::StatusCodeException &)
-    {
-      mf::LogWarning("LArPandora") << "CreatePandoraDetectorGaps - unable to create line gap, insufficient or invalid information supplied " << std::endl;
-    }
 
-    try
-    {
-      parameters.m_lineGapType = pandora::TPC_WIRE_GAP_VIEW_V;
-      parameters.m_lineStartX = -std::numeric_limits<float>::max();
-      parameters.m_lineEndX = std::numeric_limits<float>::max();
-      parameters.m_lineStartZ = crpGapLowerZ_y;
-      parameters.m_lineEndZ = crpGapUpperZ_y;
-    }
-    catch (const pandora::StatusCodeException &)
-    {
-      mf::LogWarning("LArPandora") << "CreatePandoraDetectorGaps - invalid line gap parameter provided, all assigned values must be finite, line gap omitted " << std::endl;
-    }
-    try
-    {
-      PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraApi::Geometry::LineGap::Create(*pPandora, parameters));
-    }
-    catch (const pandora::StatusCodeException &)
-    {
-      mf::LogWarning("LArPandora") << "CreatePandoraDetectorGaps - unable to create line gap, insufficient or invalid information supplied " << std::endl;
-    }
+	    PandoraApi::Geometry::LineGap::Parameters parameters;
+	    try
+	    {
+	      parameters.m_lineGapType = pandora::TPC_WIRE_GAP_VIEW_U;
+	      //parameters.m_lineStartX = -std::numeric_limits<float>::max();
+	      //parameters.m_lineEndX = std::numeric_limits<float>::max();
+	      parameters.m_lineStartX = driftVolume.GetCenterX() - 0.5f * driftVolume.GetWidthX();
+	      parameters.m_lineEndX = driftVolume.GetCenterX() + 0.5f * driftVolume.GetWidthX();
+	      parameters.m_lineStartZ = crpGapLowerZ_z;
+	      parameters.m_lineEndZ = crpGapUpperZ_z;
+	    }
+	    catch (const pandora::StatusCodeException &)
+	    {
+	      mf::LogWarning("LArPandora") << "CreatePandoraDetectorGaps - invalid line gap parameter provided, all assigned values must be finite, line gap omitted " << std::endl;
+	    }
+	    try
+	    {
+	      PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraApi::Geometry::LineGap::Create(*pPandora, parameters));
+	    }
+	    catch (const pandora::StatusCodeException &)
+	    {
+	      mf::LogWarning("LArPandora") << "CreatePandoraDetectorGaps - unable to create line gap, insufficient or invalid information supplied " << std::endl;
+	    }
 
+	    try
+	    {
+	      parameters.m_lineGapType = pandora::TPC_WIRE_GAP_VIEW_V;
+	      //parameters.m_lineStartX = -std::numeric_limits<float>::max();
+	      //parameters.m_lineEndX = std::numeric_limits<float>::max();
+	      parameters.m_lineStartX = driftVolume.GetCenterX() - 0.5f * driftVolume.GetWidthX();
+	      parameters.m_lineEndX = driftVolume.GetCenterX() + 0.5f * driftVolume.GetWidthX();
+	      parameters.m_lineStartZ = crpGapLowerZ_y;
+	      parameters.m_lineEndZ = crpGapUpperZ_y;
+	    }
+	    catch (const pandora::StatusCodeException &)
+	    {
+	      mf::LogWarning("LArPandora") << "CreatePandoraDetectorGaps - invalid line gap parameter provided, all assigned values must be finite, line gap omitted " << std::endl;
+	    }
+	    try
+	    {
+	      PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraApi::Geometry::LineGap::Create(*pPandora, parameters));
+	    }
+	    catch (const pandora::StatusCodeException &)
+	    {
+	      mf::LogWarning("LArPandora") << "CreatePandoraDetectorGaps - unable to create line gap, insufficient or invalid information supplied " << std::endl;
+	    }
+       }
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandora/LArPandoraInterface/LArPandoraInput.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraInput.cxx
@@ -232,19 +232,16 @@ void LArPandoraInput::CreatePandoraDetectorGaps(const Settings &settings, const 
         
         if (isDualPhase)
         {
-            const float gapSizeY (std::fabs(gap.GetY2() - gap.GetY1())); //Could have chosen Z here, resulting in switching Y<->Z and U<->V in the try{...} block below
-            
-            const float maxGapSize (30.); //Match the maxDisplacement variable hard-coded value in LArPandoraGeometry
-             
+            const bool  isGapInU ((std::fabs(gap.GetY2() - gap.GetY1()) > gap.GetMaxGapSize())); //Could have chosen Z here, resulting in switching Y<->Z and U<->V in the try{...} block below
+
             try
             {
-                parameters.m_lineGapType = ((gapSizeY > maxGapSize) ? pandora::TPC_WIRE_GAP_VIEW_U : pandora::TPC_WIRE_GAP_VIEW_V); //If gapSizeY is too large then the gap is in Z, therefore should be in kU (i.e. kZ)
+                parameters.m_lineGapType = ( isGapInU ? pandora::TPC_WIRE_GAP_VIEW_U : pandora::TPC_WIRE_GAP_VIEW_V); //If gapSizeY is too large then the gap is in Z, therefore should be in kU (i.e. kZ)
                 parameters.m_lineStartX = gap.GetX2();
                 parameters.m_lineEndX = gap.GetX1();
-                parameters.m_lineStartZ = ((gapSizeY > maxGapSize) ? gap.GetZ1() : gap.GetY1());
-                parameters.m_lineEndZ = ((gapSizeY > maxGapSize) ? gap.GetZ2() : gap.GetY2());
+                parameters.m_lineStartZ = ( isGapInU ? gap.GetZ1() : gap.GetY1());
+                parameters.m_lineEndZ = ( isGapInU ? gap.GetZ2() : gap.GetY2());
             }
-            
             catch (const pandora::StatusCodeException &)
             {
                 mf::LogWarning("LArPandora") << "CreatePandoraDetectorGaps - invalid line gap parameter provided, all assigned values must be finite, line gap omitted " << std::endl;
@@ -261,7 +258,6 @@ void LArPandoraInput::CreatePandoraDetectorGaps(const Settings &settings, const 
             }
             continue; //No drift gaps in DP
         }
-        
         try
         {
             parameters.m_lineGapType = pandora::TPC_DRIFT_GAP;

--- a/larpandora/LArPandoraInterface/LArPandoraInput.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraInput.cxx
@@ -252,8 +252,10 @@ void LArPandoraInput::CreatePandoraDetectorGaps(const Settings &settings, const 
     }
 
     //Create CRP gaps for DP
+    art::ServiceHandle<geo::Geometry const> theGeometry;
     const bool isDualPhase(theGeometry->MaxPlanes() == 2);
-    if(!isDualPhase) return;
+    const int nCRPs(theGeometry->NTPC());
+    if(!isDualPhase || nCRPs!=4) return; //only add CRP gaps if ProtoDUNE DP
 
     const double crpGapLowerZ_y(-0.64875), crpGapUpperZ_y(0.66375);
     const double crpGapLowerZ_z(299.851), crpGapUpperZ_z(301.164);

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -1,14 +1,14 @@
 # The parent line must be the first non-comment line in the file
 # This line defines the product name and version
-parent	larpandora	v08_12_07
+parent	larpandora	v08_12_08
 defaultqual	e19
 #
 fcldir  product_dir job
 fwdir   product_dir scripts
 #
 product         version
-larreco         v08_32_00
-larpandoracontent v03_15_16
+larreco         v08_32_01
+larpandoracontent v03_16_00
 
 cetbuildtools	v7_15_01	-	only_for_build
 end_product_list


### PR DESCRIPTION
Added the DP-type gaps via _**isDualPhase**_ flag. 

For CRP gaps : 4 volumes are created, one per CRP, which leads to the creation of PandoraDetectorGaps. 
For LEM gaps, 2 bits were modified (both in the ReadoutGap function in the Input.cxx : 1) the way the planes and view number are called which doesn't correspond anymore to the iterator but instead comes directly from the art::ServiceHandle geometry object. **_THIS IMPACTS SP_** 2) added isDualPhase flag when deciding which view a gap belongs to.