### PR TITLE
Feature/argoneut reco

### DIFF
--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/CMakeLists.txt
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_subdirectory(Cheating)
 
 art_make(TOOL_LIBRARIES
+  larpandora_LArPandoraInterface
   larpandora_LArPandoraEventBuilding_LArPandoraShower_Algs
   larreco_Calorimetry
   LArPandoraContent

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerPandoraSlidingFitTrackFinder_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerPandoraSlidingFitTrackFinder_tool.cc
@@ -16,6 +16,14 @@
 #include "lardataobj/RecoBase/Track.h"
 #include "lardataobj/RecoBase/Shower.h"
 
+#include "larcore/Geometry/Geometry.h"
+#include "larcorealg/Geometry/GeometryCore.h"
+#include "larcorealg/Geometry/PlaneGeo.h"
+#include "larcorealg/Geometry/TPCGeo.h"
+
+#include "larpandora/LArPandoraInterface/LArPandoraHelper.h"
+
+
 namespace ShowerRecoTools{
 
   class ShowerPandoraSlidingFitTrackFinder:IShowerTool {
@@ -119,7 +127,7 @@ namespace ShowerRecoTools{
 
     // ATTN: Expectations here are that the input geometry corresponds to either a single or dual phase LArTPC.  For single phase we expect
     // three views, U, V and either W or Y, for dual phase we expect two views, W and Y.
-    const bool isDualPhase(fGeom->MaxPlanes() == 2);
+    const bool isDualPhase(lar_pandora::LArPandoraHelper::IsDualPhase());
 
     if (nWirePlanes != planeSet.size())
       throw cet::exception("LArPandoraTrackCreation") << " LArPandoraGeometry::LoadGeometry --- geometry description for wire plane(s) missing ";

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerPandoraSlidingFitTrackFinder_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerPandoraSlidingFitTrackFinder_tool.cc
@@ -12,17 +12,10 @@
 
 //LArSoft Includes
 #include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h"
+#include "larpandora/LArPandoraInterface/LArPandoraHelper.h"
 #include "larpandoracontent/LArHelpers/LArPfoHelper.h"
 #include "lardataobj/RecoBase/Track.h"
 #include "lardataobj/RecoBase/Shower.h"
-
-#include "larcore/Geometry/Geometry.h"
-#include "larcorealg/Geometry/GeometryCore.h"
-#include "larcorealg/Geometry/PlaneGeo.h"
-#include "larcorealg/Geometry/TPCGeo.h"
-
-#include "larpandora/LArPandoraInterface/LArPandoraHelper.h"
-
 
 namespace ShowerRecoTools{
 

--- a/larpandora/LArPandoraEventBuilding/LArPandoraTrackCreation_module.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraTrackCreation_module.cc
@@ -134,7 +134,7 @@ void LArPandoraTrackCreation::produce(art::Event &evt)
     if (isDualPhase && (!planeSet.count(geo::kW) || !planeSet.count(geo::kY)))
         throw cet::exception("LArPandoraTrackCreation") << " LArPandoraGeometry::LoadGeometry --- dual phase scenario; expect to find w and y views ";
 
-    if (isDualPhase && (!planeSet.count(geo::kU) || !planeSet.count(geo::kV) || (planeSet.count(geo::kW) && planeSet.count(geo::kY))))
+    if (!isDualPhase && (!planeSet.count(geo::kU) || !planeSet.count(geo::kV) || (planeSet.count(geo::kW) && planeSet.count(geo::kY))))
         throw cet::exception("LArPandoraTrackCreation") << " LArPandoraGeometry::LoadGeometry --- single phase scenatio; expect to find u and v views; if there is one further view, it must be w or y ";
 
     const bool useYPlane((nWirePlanes > 2) && planeSet.count(geo::kY));

--- a/larpandora/LArPandoraEventBuilding/LArPandoraTrackCreation_module.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraTrackCreation_module.cc
@@ -126,7 +126,7 @@ void LArPandoraTrackCreation::produce(art::Event &evt)
 
     // ATTN: Expectations here are that the input geometry corresponds to either a single or dual phase LArTPC.  For single phase we expect
     // three views, U, V and either W or Y, for dual phase we expect two views, W and Y.
-    const bool isDualPhase(theGeometry->MaxPlanes() == 2);
+    const bool isDualPhase(LArPandoraHelper::IsDualPhase());
 
     if (nWirePlanes != planeSet.size())
         throw cet::exception("LArPandoraTrackCreation") << " LArPandoraGeometry::LoadGeometry --- geometry description for wire plane(s) missing ";
@@ -134,7 +134,7 @@ void LArPandoraTrackCreation::produce(art::Event &evt)
     if (isDualPhase && (!planeSet.count(geo::kW) || !planeSet.count(geo::kY)))
         throw cet::exception("LArPandoraTrackCreation") << " LArPandoraGeometry::LoadGeometry --- dual phase scenario; expect to find w and y views ";
 
-    if (!isDualPhase && (!planeSet.count(geo::kU) || !planeSet.count(geo::kV) || (planeSet.count(geo::kW) && planeSet.count(geo::kY))))
+    if (isDualPhase && (!planeSet.count(geo::kU) || !planeSet.count(geo::kV) || (planeSet.count(geo::kW) && planeSet.count(geo::kY))))
         throw cet::exception("LArPandoraTrackCreation") << " LArPandoraGeometry::LoadGeometry --- single phase scenatio; expect to find u and v views; if there is one further view, it must be w or y ";
 
     const bool useYPlane((nWirePlanes > 2) && planeSet.count(geo::kY));

--- a/larpandora/LArPandoraInterface/LArPandoraGeometry.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraGeometry.cxx
@@ -7,11 +7,13 @@
 #include "cetlib_except/exception.h"
 
 #include "larcore/Geometry/Geometry.h"
+#include "larcorealg/Geometry/GeometryCore.h"
 #include "larcorealg/Geometry/PlaneGeo.h"
 #include "larcorealg/Geometry/TPCGeo.h"
 #include "larcorealg/Geometry/WireGeo.h"
 
 #include "larpandora/LArPandoraInterface/LArPandoraGeometry.h"
+#include "larpandora/LArPandoraInterface/LArPandoraHelper.h"
 
 #include <iomanip>
 #include <set>
@@ -32,7 +34,21 @@ namespace lar_pandora {
 
     // ATTN: Expectations here are that the input geometry corresponds to either a single or dual phase LArTPC.
     art::ServiceHandle<geo::Geometry const> theGeometry;
-    const bool isDualPhase(theGeometry->MaxPlanes() == 2);
+    //std::cout << "debg sigtype = " << theGeometry->SignalTypeName(geo::_plane_sigtype) << std::endl;
+    //std::cout << "debg sigtype = " << theGeometry->SignalType() << std::endl;
+    //int nPlanes(theGeometry->Nplanes());
+    //for () {
+    //
+    //}
+    /*std::unordered_set<geo::_plane_sigtype> sigtypeSet;
+    for (readout::ROPID const& rID: theGeometry->IterateROPIDs()) {
+      std::cout << "Signal type = " << theGeometry->SignalType(rID) << std::endl;
+      (void)sigtypeSet.insert(theGeometry->SignalType(rID));
+    }*/
+    
+    //const bool isDualPhase(theGeometry->MaxPlanes() == 2);
+    //const bool isDualPhase(!sigtypeSet.count(geo::kInduction));
+    const bool isDualPhase(LArPandoraHelper::IsDualPhase());
 
     for (LArDriftVolumeList::const_iterator iter1 = driftVolumeList.begin(),
                                             iterEnd1 = driftVolumeList.end();
@@ -229,7 +245,8 @@ namespace lar_pandora {
 
     // ATTN: Expectations here are that the input geometry corresponds to either a single or dual phase LArTPC.  For single phase we expect
     // three views, U, V and either W or Y, for dual phase we expect two views, W and Y.
-    const bool isDualPhase(theGeometry->MaxPlanes() == 2);
+    //const bool isDualPhase(theGeometry->MaxPlanes() == 2);
+    const bool isDualPhase(LArPandoraHelper::IsDualPhase());
 
     if (nWirePlanes != planeSet.size())
       throw cet::exception("LArPandora")

--- a/larpandora/LArPandoraInterface/LArPandoraGeometry.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraGeometry.cxx
@@ -7,7 +7,6 @@
 #include "cetlib_except/exception.h"
 
 #include "larcore/Geometry/Geometry.h"
-#include "larcorealg/Geometry/GeometryCore.h"
 #include "larcorealg/Geometry/PlaneGeo.h"
 #include "larcorealg/Geometry/TPCGeo.h"
 #include "larcorealg/Geometry/WireGeo.h"
@@ -34,20 +33,6 @@ namespace lar_pandora {
 
     // ATTN: Expectations here are that the input geometry corresponds to either a single or dual phase LArTPC.
     art::ServiceHandle<geo::Geometry const> theGeometry;
-    //std::cout << "debg sigtype = " << theGeometry->SignalTypeName(geo::_plane_sigtype) << std::endl;
-    //std::cout << "debg sigtype = " << theGeometry->SignalType() << std::endl;
-    //int nPlanes(theGeometry->Nplanes());
-    //for () {
-    //
-    //}
-    /*std::unordered_set<geo::_plane_sigtype> sigtypeSet;
-    for (readout::ROPID const& rID: theGeometry->IterateROPIDs()) {
-      std::cout << "Signal type = " << theGeometry->SignalType(rID) << std::endl;
-      (void)sigtypeSet.insert(theGeometry->SignalType(rID));
-    }*/
-    
-    //const bool isDualPhase(theGeometry->MaxPlanes() == 2);
-    //const bool isDualPhase(!sigtypeSet.count(geo::kInduction));
     const bool isDualPhase(LArPandoraHelper::IsDualPhase());
 
     for (LArDriftVolumeList::const_iterator iter1 = driftVolumeList.begin(),
@@ -245,7 +230,6 @@ namespace lar_pandora {
 
     // ATTN: Expectations here are that the input geometry corresponds to either a single or dual phase LArTPC.  For single phase we expect
     // three views, U, V and either W or Y, for dual phase we expect two views, W and Y.
-    //const bool isDualPhase(theGeometry->MaxPlanes() == 2);
     const bool isDualPhase(LArPandoraHelper::IsDualPhase());
 
     if (nWirePlanes != planeSet.size())

--- a/larpandora/LArPandoraInterface/LArPandoraHelper.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraHelper.cxx
@@ -1500,6 +1500,20 @@ namespace lar_pandora {
     return larpandoraobj::PFParticleMetadata(pPfo->GetPropertiesMap());
   }
 
+  bool
+  LArPandoraHelper::IsDualPhase()
+  {
+    art::ServiceHandle<geo::Geometry const> theGeometry;
+    std::unordered_set<geo::_plane_sigtype> sigtypeSet;
+    for (readout::ROPID const& rID: theGeometry->IterateROPIDs()) {
+      //std::cout << "Signal type = " << theGeometry->SignalType(rID) << std::endl;
+      //(void)sigtypeSet.insert(theGeometry->SignalType(rID));
+      sigtypeSet.insert(theGeometry->SignalType(rID));
+    }
+    return !(sigtypeSet.count(geo::kInduction));
+  }
+
+
   //------------------------------------------------------------------------------------------------------------------------------------------
   //------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/larpandora/LArPandoraInterface/LArPandoraHelper.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraHelper.cxx
@@ -1508,7 +1508,7 @@ namespace lar_pandora {
     for (readout::ROPID const& rID: theGeometry->IterateROPIDs()) {
       sigtypeSet.insert(theGeometry->SignalType(rID));
     }
-    return ((!sigtypeSet.count(geo::kInduction) || !sigtypeSet.count(geo::kCollection)) && !sigtypeSet.count(geo::kMysteryType));
+    return (!(sigtypeSet.count(geo::kInduction) && sigtypeSet.count(geo::kCollection)) && !sigtypeSet.count(geo::kMysteryType));
   }
 
   //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandora/LArPandoraInterface/LArPandoraHelper.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraHelper.cxx
@@ -1506,13 +1506,10 @@ namespace lar_pandora {
     art::ServiceHandle<geo::Geometry const> theGeometry;
     std::unordered_set<geo::_plane_sigtype> sigtypeSet;
     for (readout::ROPID const& rID: theGeometry->IterateROPIDs()) {
-      //std::cout << "Signal type = " << theGeometry->SignalType(rID) << std::endl;
-      //(void)sigtypeSet.insert(theGeometry->SignalType(rID));
       sigtypeSet.insert(theGeometry->SignalType(rID));
     }
-    return !(sigtypeSet.count(geo::kInduction));
+    return ((!sigtypeSet.count(geo::kInduction) || !sigtypeSet.count(geo::kCollection)) && !sigtypeSet.count(geo::kMysteryType));
   }
-
 
   //------------------------------------------------------------------------------------------------------------------------------------------
   //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandora/LArPandoraInterface/LArPandoraHelper.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraHelper.cxx
@@ -29,6 +29,9 @@
 #include "nusimdata/SimulationBase/MCTruth.h"
 
 #include "larcore/Geometry/Geometry.h"
+#include "larcore/Geometry/Geometry.h"
+#include "larcorealg/Geometry/GeometryCore.h"
+#include "larcorealg/Geometry/PlaneGeo.h"
 #include "larcoreobj/SimpleTypesAndConstants/RawTypes.h"
 #include "lardata/DetectorInfoServices/DetectorClocksService.h"
 

--- a/larpandora/LArPandoraInterface/LArPandoraHelper.h
+++ b/larpandora/LArPandoraInterface/LArPandoraHelper.h
@@ -8,7 +8,9 @@
 #define LAR_PANDORA_HELPER_H
 
 #include "art/Framework/Principal/Event.h"
-
+#include "larcore/Geometry/Geometry.h"
+#include "larcorealg/Geometry/GeometryCore.h"
+#include "larcorealg/Geometry/PlaneGeo.h"
 #include "lardataobj/Simulation/SimChannel.h"
 
 #include <map>
@@ -738,6 +740,17 @@ namespace lar_pandora {
      */
     static larpandoraobj::PFParticleMetadata GetPFParticleMetadata(
       const pandora::ParticleFlowObject* const pPfo);
+
+    /**
+     *  @brief  Check if geometry has collection views only
+     *
+     *  @param  
+     *
+     *  @return true/false
+     */
+    static bool IsDualPhase();
+
+
   };
 
 } // namespace lar_pandora

--- a/larpandora/LArPandoraInterface/LArPandoraHelper.h
+++ b/larpandora/LArPandoraInterface/LArPandoraHelper.h
@@ -748,7 +748,6 @@ namespace lar_pandora {
      */
     static bool IsDualPhase();
 
-
   };
 
 } // namespace lar_pandora

--- a/larpandora/LArPandoraInterface/LArPandoraHelper.h
+++ b/larpandora/LArPandoraInterface/LArPandoraHelper.h
@@ -9,10 +9,6 @@
 
 #include "art/Framework/Principal/Event.h"
 
-#include "larcore/Geometry/Geometry.h"
-#include "larcorealg/Geometry/GeometryCore.h"
-#include "larcorealg/Geometry/PlaneGeo.h"
-
 #include "lardataobj/Simulation/SimChannel.h"
 
 #include <map>

--- a/larpandora/LArPandoraInterface/LArPandoraHelper.h
+++ b/larpandora/LArPandoraInterface/LArPandoraHelper.h
@@ -8,9 +8,11 @@
 #define LAR_PANDORA_HELPER_H
 
 #include "art/Framework/Principal/Event.h"
+
 #include "larcore/Geometry/Geometry.h"
 #include "larcorealg/Geometry/GeometryCore.h"
 #include "larcorealg/Geometry/PlaneGeo.h"
+
 #include "lardataobj/Simulation/SimChannel.h"
 
 #include <map>
@@ -742,7 +744,7 @@ namespace lar_pandora {
       const pandora::ParticleFlowObject* const pPfo);
 
     /**
-     *  @brief  Check if geometry has collection views only
+     *  @brief  Check if geometry is Dual Phase (i.e. has collection or induction views only)
      *
      *  @param  
      *

--- a/larpandora/LArPandoraInterface/LArPandoraInput.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraInput.cxx
@@ -5,6 +5,7 @@
  */
 
 #include "larcore/Geometry/Geometry.h"
+#include "larcorealg/Geometry/GeometryCore.h"
 #include "larcorealg/Geometry/PlaneGeo.h"
 #include "larcorealg/Geometry/TPCGeo.h"
 #include "larcoreobj/SimpleTypesAndConstants/PhysicalConstants.h"
@@ -32,6 +33,7 @@
 
 #include "larpandora/LArPandoraInterface/ILArPandora.h"
 #include "larpandora/LArPandoraInterface/LArPandoraInput.h"
+#include "larpandora/LArPandoraInterface/LArPandoraHelper.h"
 
 #include <limits>
 
@@ -55,7 +57,8 @@ namespace lar_pandora {
 
     art::ServiceHandle<geo::Geometry const> theGeometry;
     auto const detProp = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(e);
-    const bool isDualPhase(theGeometry->MaxPlanes() == 2);
+    //const bool isDualPhase(theGeometry->MaxPlanes() == 2);
+    const bool isDualPhase(lar_pandora::LArPandoraHelper::IsDualPhase());
 
     // Loop over ART hits
     int hitCounter(settings.m_hitCounterOffset);
@@ -250,7 +253,8 @@ namespace lar_pandora {
   {
     //ATTN - Unlike SP, DP detector gaps are not in the drift direction
     art::ServiceHandle<geo::Geometry const> theGeometry;
-    const bool isDualPhase(theGeometry->MaxPlanes() == 2);
+    //const bool isDualPhase(theGeometry->MaxPlanes() == 2);
+    const bool isDualPhase(LArPandoraHelper::IsDualPhase());
 
     mf::LogDebug("LArPandora") << " *** LArPandoraInput::CreatePandoraDetectorGaps(...) *** "
                                << std::endl;
@@ -346,7 +350,8 @@ namespace lar_pandora {
     const lariov::ChannelStatusProvider& channelStatus(
       art::ServiceHandle<lariov::ChannelStatusService const>()->GetProvider());
 
-    const bool isDualPhase(theGeometry->MaxPlanes() == 2);
+    //const bool isDualPhase(theGeometry->MaxPlanes() == 2);
+    const bool isDualPhase(LArPandoraHelper::IsDualPhase());
 
     for (unsigned int icstat = 0; icstat < theGeometry->Ncryostats(); ++icstat) {
       for (unsigned int itpc = 0; itpc < theGeometry->NTPC(icstat); ++itpc) {

--- a/larpandora/LArPandoraInterface/LArPandoraInput.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraInput.cxx
@@ -5,7 +5,6 @@
  */
 
 #include "larcore/Geometry/Geometry.h"
-#include "larcorealg/Geometry/GeometryCore.h"
 #include "larcorealg/Geometry/PlaneGeo.h"
 #include "larcorealg/Geometry/TPCGeo.h"
 #include "larcoreobj/SimpleTypesAndConstants/PhysicalConstants.h"
@@ -57,7 +56,6 @@ namespace lar_pandora {
 
     art::ServiceHandle<geo::Geometry const> theGeometry;
     auto const detProp = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(e);
-    //const bool isDualPhase(theGeometry->MaxPlanes() == 2);
     const bool isDualPhase(lar_pandora::LArPandoraHelper::IsDualPhase());
 
     // Loop over ART hits
@@ -253,7 +251,6 @@ namespace lar_pandora {
   {
     //ATTN - Unlike SP, DP detector gaps are not in the drift direction
     art::ServiceHandle<geo::Geometry const> theGeometry;
-    //const bool isDualPhase(theGeometry->MaxPlanes() == 2);
     const bool isDualPhase(LArPandoraHelper::IsDualPhase());
 
     mf::LogDebug("LArPandora") << " *** LArPandoraInput::CreatePandoraDetectorGaps(...) *** "
@@ -350,7 +347,6 @@ namespace lar_pandora {
     const lariov::ChannelStatusProvider& channelStatus(
       art::ServiceHandle<lariov::ChannelStatusService const>()->GetProvider());
 
-    //const bool isDualPhase(theGeometry->MaxPlanes() == 2);
     const bool isDualPhase(LArPandoraHelper::IsDualPhase());
 
     for (unsigned int icstat = 0; icstat < theGeometry->Ncryostats(); ++icstat) {

--- a/larpandora/LArPandoraInterface/LArPandoraInput.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraInput.cxx
@@ -56,7 +56,7 @@ namespace lar_pandora {
 
     art::ServiceHandle<geo::Geometry const> theGeometry;
     auto const detProp = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(e);
-    const bool isDualPhase(lar_pandora::LArPandoraHelper::IsDualPhase());
+    const bool isDualPhase(LArPandoraHelper::IsDualPhase());
 
     // Loop over ART hits
     int hitCounter(settings.m_hitCounterOffset);


### PR DESCRIPTION
A new LArPandoraHelper method has been added and used to check if a detector is dual phase. This change allows running the reconstruction for new detector geometries, such as ArgoNeuT.