### PR TITLE
Improved Shower Cheating

### DIFF
--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/LArPandoraShowerAlg.cxx
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/LArPandoraShowerAlg.cxx
@@ -360,6 +360,67 @@ double shower::LArPandoraShowerAlg::SpacePointPerpendicular(art::Ptr<recob::Spac
   return pos.Mag();
 }
 
+  //Function to calculate the RMS at segements of the shower and calculate the gradient of this. If negative then the direction is pointing the opposite way to the correct one
+  double shower::LArPandoraShowerAlg::RMSShowerGradient(std::vector<art::Ptr<recob::SpacePoint> >& sps, const TVector3& ShowerCentre, const TVector3& Direction, const unsigned nSegments) const {
+
+    //Order the spacepoints
+    this->OrderShowerSpacePoints(sps,ShowerCentre,Direction);
+
+    //Get the length of the shower.
+    const double minProj = this->SpacePointProjection(sps[0],ShowerCentre,Direction);
+    const double maxProj = this->SpacePointProjection(sps[sps.size()-1],ShowerCentre,Direction);
+
+    const double length = (maxProj-minProj);
+    const double segmentsize = length / nSegments;
+
+    std::map<int, std::vector<float> > len_segment_map;
+
+    //Split the the spacepoints into segments.
+    for(auto const& sp: sps){
+
+      //Get the the projected length
+      const double len = this->SpacePointProjection(sp,ShowerCentre,Direction);
+
+      //Get the length to the projection
+      const double  len_perp = this->SpacePointPerpendicular(sp,ShowerCentre,Direction,len);
+
+      int sg_len = std::round(len/segmentsize);
+      //TODO: look at this:
+      //int sg_len = round(len/segmentsize+fNSegments/2); //Add to make positive
+      len_segment_map[sg_len].push_back(len_perp);
+    }
+
+    int counter = 0;
+    float sumx  = 0;
+    float sumy  = 0;
+    float sumx2 = 0;
+    float sumxy = 0;
+
+    //Get the rms of the segments and caclulate the gradient.
+    for(auto const& segment: len_segment_map){
+      if (segment.second.size()<2) continue;
+      float RMS = this->CalculateRMS(segment.second);
+      //Calculate the gradient using regression
+      sumx  += segment.first;
+      sumy  += RMS;
+      sumx2 += segment.first * segment.first;
+      sumxy += RMS * segment.first;
+      ++counter;
+    }
+
+    return (counter*sumxy - sumx*sumy)/(counter*sumx2 - sumx*sumx);
+  }
+
+  double shower::LArPandoraShowerAlg::CalculateRMS(const std::vector<float>& perps) const {
+
+    double sum  = 0;
+    for (const auto &perp : perps){
+      sum += perp*perp;
+    }
+    // No need to bounds check as we have done so already
+    return std::sqrt(sum/(perps.size()-1));
+  }
+
 double shower::LArPandoraShowerAlg::SCECorrectPitch(double const& pitch, TVector3 const& pos,
     TVector3 const& dir, unsigned int const& TPC) const {
   const geo::Point_t geoPos{pos.X(), pos.Y(), pos.z()};

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/LArPandoraShowerAlg.cxx
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/LArPandoraShowerAlg.cxx
@@ -360,8 +360,14 @@ double shower::LArPandoraShowerAlg::SpacePointPerpendicular(art::Ptr<recob::Spac
   return pos.Mag();
 }
 
-  //Function to calculate the RMS at segements of the shower and calculate the gradient of this. If negative then the direction is pointing the opposite way to the correct one
-  double shower::LArPandoraShowerAlg::RMSShowerGradient(std::vector<art::Ptr<recob::SpacePoint> >& sps, const TVector3& ShowerCentre, const TVector3& Direction, const unsigned nSegments) const {
+  //Function to calculate the RMS at segments of the shower and calculate the gradient of this. If negative then the direction is pointing the opposite way to the correct one
+  double shower::LArPandoraShowerAlg::RMSShowerGradient(std::vector<art::Ptr<recob::SpacePoint> >& sps, const TVector3& ShowerCentre, const TVector3& Direction, const unsigned int nSegments) const {
+
+    if (nSegments == 0)
+      throw cet::exception("LArPandoraShowerAlg") << "Unable to calculate RMS Shower Gradient with 0 segments" << std::endl;
+
+    if (sps.size() < 3)
+      return 0;
 
     //Order the spacepoints
     this->OrderShowerSpacePoints(sps,ShowerCentre,Direction);
@@ -372,6 +378,9 @@ double shower::LArPandoraShowerAlg::SpacePointPerpendicular(art::Ptr<recob::Spac
 
     const double length = (maxProj-minProj);
     const double segmentsize = length / nSegments;
+
+    if (segmentsize < std::numeric_limits<double>::epsilon())
+      return 0;
 
     std::map<int, std::vector<float> > len_segment_map;
 
@@ -385,21 +394,24 @@ double shower::LArPandoraShowerAlg::SpacePointPerpendicular(art::Ptr<recob::Spac
       const double  len_perp = this->SpacePointPerpendicular(sp,ShowerCentre,Direction,len);
 
       int sg_len = std::round(len/segmentsize);
-      //TODO: look at this:
-      //int sg_len = round(len/segmentsize+fNSegments/2); //Add to make positive
       len_segment_map[sg_len].push_back(len_perp);
     }
 
     int counter = 0;
-    float sumx  = 0;
-    float sumy  = 0;
-    float sumx2 = 0;
-    float sumxy = 0;
+    float sumx  = 0.f;
+    float sumy  = 0.f;
+    float sumx2 = 0.f;
+    float sumxy = 0.f;
 
     //Get the rms of the segments and caclulate the gradient.
     for(auto const& segment: len_segment_map){
       if (segment.second.size()<2) continue;
       float RMS = this->CalculateRMS(segment.second);
+
+      // Check if the calculation failed
+      if (RMS < 0)
+        continue;
+
       //Calculate the gradient using regression
       sumx  += segment.first;
       sumy  += RMS;
@@ -408,16 +420,21 @@ double shower::LArPandoraShowerAlg::SpacePointPerpendicular(art::Ptr<recob::Spac
       ++counter;
     }
 
-    return (counter*sumxy - sumx*sumy)/(counter*sumx2 - sumx*sumx);
+    const float denom = counter*sumx2 - sumx*sumx;
+
+    return std::abs(denom) < std::numeric_limits<float>::epsilon() ? 0 : (counter*sumxy - sumx*sumy)/denom;
   }
 
   double shower::LArPandoraShowerAlg::CalculateRMS(const std::vector<float>& perps) const {
 
-    double sum  = 0;
+    if (perps.size() < 2)
+      return std::numeric_limits<double>::lowest();
+
+    float sum = 0;
     for (const auto &perp : perps){
       sum += perp*perp;
     }
-    // No need to bounds check as we have done so already
+
     return std::sqrt(sum/(perps.size()-1));
   }
 

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/LArPandoraShowerAlg.h
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/LArPandoraShowerAlg.h
@@ -100,6 +100,10 @@ class shower::LArPandoraShowerAlg {
     double SpacePointPerpendicular(art::Ptr<recob::SpacePoint> const& sp, TVector3 const& vertex,
         TVector3 const& direction, double proj) const;
 
+    double RMSShowerGradient(std::vector<art::Ptr<recob::SpacePoint> >& sps, const TVector3& ShowerCentre, const TVector3& Direction, const unsigned nSegments) const;
+
+    double CalculateRMS(const std::vector<float>& perps) const;
+
   // The SCE service requires thing in geo::Point/Vector form, so overload and be nice
     double SCECorrectPitch(double const& pitch, TVector3 const& pos, TVector3 const& dir, unsigned int const& TPC) const;
     double SCECorrectPitch(double const& pitch, geo::Point_t const& pos, geo::Vector_t const& dir, unsigned int const& TPC) const;

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/LArPandoraShowerAlg.h
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/LArPandoraShowerAlg.h
@@ -100,7 +100,7 @@ class shower::LArPandoraShowerAlg {
     double SpacePointPerpendicular(art::Ptr<recob::SpacePoint> const& sp, TVector3 const& vertex,
         TVector3 const& direction, double proj) const;
 
-    double RMSShowerGradient(std::vector<art::Ptr<recob::SpacePoint> >& sps, const TVector3& ShowerCentre, const TVector3& Direction, const unsigned nSegments) const;
+    double RMSShowerGradient(std::vector<art::Ptr<recob::SpacePoint> >& sps, const TVector3& ShowerCentre, const TVector3& Direction, const unsigned int nSegments) const;
 
     double CalculateRMS(const std::vector<float>& perps) const;
 

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/LArPandoraModularShowerCreation_module.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/LArPandoraModularShowerCreation_module.cc
@@ -239,22 +239,25 @@ void reco::shower::LArPandoraModularShowerCreation::produce(art::Event& evt)
     if (!showerClusters.size())
       continue;
 
+    if (fVerbose>1)
+      mf::LogInfo("LArPandoraModularShowerCreation") << "Running on shower: " << shower_iter << std::endl;
+
     //Calculate the shower properties
     //Loop over the shower tools
     int err = 0;
-    unsigned int i = 0;
-    for (auto const& fShowerTool : fShowerTools) {
+    for (unsigned int i=0; i<fShowerTools.size(); i++) {
 
       //Calculate the metric
+      if (fVerbose>1)
+        mf::LogInfo("LArPandoraModularShowerCreation") << "Running shower tool: " << fShowerToolNames[i] << std::endl;
       std::string evd_disp_append = fShowerToolNames[i] + "_iteration" + std::to_string(0) + "_" + this->moduleDescription().moduleLabel();
 
-      err = fShowerTool->RunShowerTool(pfp, evt, showerEleHolder, evd_disp_append);
+      err = fShowerTools[i]->RunShowerTool(pfp, evt, showerEleHolder, evd_disp_append);
 
       if (err && fVerbose) {
         mf::LogError("LArPandoraModularShowerCreation") << "Error in shower tool: " << fShowerToolNames[i]
                                                         << " with code: " << err << std::endl;
       }
-      ++i;
     }
 
     //If we are are not allowing partial shower check all of the things

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/Cheating/ShowerDirectionCheater_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/Cheating/ShowerDirectionCheater_tool.cc
@@ -29,9 +29,8 @@ namespace ShowerRecoTools {
 
     private:
 
-      TVector3 ShowerPCAVector(std::vector<art::Ptr<recob::SpacePoint> >& spacePoints_pfp, art::FindManyP<recob::Hit>& fmh, TVector3& ShowerCentre);
-      double RMSShowerGradient(std::vector<art::Ptr<recob::SpacePoint> >& sps, TVector3& ShowerCentre, TVector3& Direction);
-      double CalculateRMS(std::vector<float> perps);
+      double RMSShowerGradient(std::vector<art::Ptr<recob::SpacePoint> >& sps, const TVector3& ShowerCentre, const TVector3& Direction) const;
+      double CalculateRMS(const std::vector<float>& perps) const;
 
       //Algorithm functions
       shower::LArPandoraShowerCheatingAlg fLArPandoraShowerCheatingAlg;
@@ -40,19 +39,19 @@ namespace ShowerRecoTools {
       art::ServiceHandle<art::TFileService> tfs;
 
       //fcl
-      art::InputTag fPFParticleLabel;
-      float fNSegments; //Number of segement to split the shower into the perforam the RMSFlip.
-      bool fRMSFlip;    //Flip the direction by considering the rms.
-      bool fVertexFlip; //Flip the direction by considering the vertex position relative to the center position.
+      const art::InputTag fPFParticleLabel;
+      const float fNSegments; //Number of segement to split the shower into the perforam the RMSFlip.
+      const bool fRMSFlip;    //Flip the direction by considering the rms.
+      const bool fVertexFlip; //Flip the direction by considering the vertex position relative to the center position.
 
       //TTree Branch variables
       TTree* Tree;
       float vertexDotProduct;
       float rmsGradient;
 
-      std::string fShowerStartPositionInputLabel;
-      std::string fTrueParticleInputLabel;
-      std::string fShowerDirectionOutputLabel;
+      const std::string fShowerStartPositionInputLabel;
+      const std::string fTrueParticleInputLabel;
+      const std::string fShowerDirectionOutputLabel;
 
   };
 
@@ -68,7 +67,7 @@ namespace ShowerRecoTools {
     fTrueParticleInputLabel(pset.get<std::string>("TrueParticleInputLabel")),
     fShowerDirectionOutputLabel(pset.get<std::string>("ShowerDirectionOutputLabel"))
   {
-    if (vertexDotProduct||rmsGradient){
+    if (fVertexFlip || fRMSFlip){
       Tree = tfs->make<TTree>("DebugTreeDirCheater", "DebugTree from shower direction cheater");
       if (fVertexFlip) Tree->Branch("vertexDotProduct",&vertexDotProduct);
       if (fRMSFlip)    Tree->Branch("rmsGradient",&rmsGradient);
@@ -120,10 +119,15 @@ namespace ShowerRecoTools {
         return 1;
       }
       trueParticle = trueParticles[ShowerTrackInfo.first];
+      ShowerEleHolder.SetElement(trueParticle,fTrueParticleInputLabel);
     }
 
-    TVector3 trueDir = {trueParticle->Px(),trueParticle->Py(),trueParticle->Pz()};
-    trueDir = trueDir.Unit(); // TODO: Can probably remove?
+    if (!trueParticle){
+      mf::LogError("ShowerDirectionCheater") << "True shower not found, returning";
+      return 1;
+    }
+
+    TVector3 trueDir = TVector3{trueParticle->Px(),trueParticle->Py(),trueParticle->Pz()}.Unit();
 
     TVector3 trueDirErr = {-999,-999,-999};
     ShowerEleHolder.SetElement(trueDir,trueDirErr,fShowerDirectionOutputLabel);
@@ -143,12 +147,15 @@ namespace ShowerRecoTools {
       }
       std::vector<art::Ptr<recob::SpacePoint> > spacePoints = fmspp.at(pfparticle.key());
 
-      if (spacePoints.empty()) return 1;
+      if (spacePoints.empty()) {
+        mf::LogError("ShowerDirectionCheater") << "No spacepoints in shower" << std::endl;
+        return 1;
+      }
 
       //Get Shower Centre
       float TotalCharge;
 
-      TVector3 ShowerCentre = IShowerTool::GetLArPandoraShowerAlg().ShowerCentre(clockData, detProp, spacePoints, fmh, TotalCharge);
+      const TVector3 ShowerCentre = IShowerTool::GetLArPandoraShowerAlg().ShowerCentre(clockData, detProp, spacePoints, fmh, TotalCharge);
 
       //Check if we are pointing the correct direction or not, First try the start position
       if(ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel) && fVertexFlip){
@@ -157,32 +164,15 @@ namespace ShowerRecoTools {
         TVector3 StartPositionVec = {-999, -999, -999};
         ShowerEleHolder.GetElement(fShowerStartPositionInputLabel,StartPositionVec);
 
-        TVector3 GeneralDir       = (ShowerCentre - StartPositionVec).Unit();
+        TVector3 GeneralDir = (ShowerCentre - StartPositionVec).Unit();
 
         //Dot product
         vertexDotProduct = trueDir.Dot(GeneralDir);
-
-        //If the dotproduct is negative the Direction needs Flipping
-        if(vertexDotProduct < 0){
-          trueDir[0] = - trueDir[0];
-          trueDir[1] = - trueDir[1];
-          trueDir[2] = - trueDir[2];
-        }
-
-        //ShowerEleHolder.SetShowerDirection(trueDir);
       }
 
       if (fRMSFlip){
-        //Otherwise Check against the RMS of the shower. Method adapated from EMShower Thanks Mike.
+        // Check against the RMS of the shower. Method adapated from EMShower Thanks Mike.
         rmsGradient = RMSShowerGradient(spacePoints,ShowerCentre,trueDir);
-        if(rmsGradient < 0){
-
-          trueDir[0] = - trueDir[0];
-          trueDir[1] = - trueDir[1];
-          trueDir[2] = - trueDir[2];
-        }
-
-        //ShowerEleHolder.SetShowerDirection(trueDir);
       }
       Tree->Fill();
     }
@@ -192,7 +182,7 @@ namespace ShowerRecoTools {
 
 
   //Function to calculate the RMS at segements of the shower and calculate the gradient of this. If negative then the direction is pointing the opposite way to the correct one
-  double ShowerDirectionCheater::RMSShowerGradient(std::vector<art::Ptr<recob::SpacePoint> >& sps, TVector3& ShowerCentre, TVector3& Direction){
+  double ShowerDirectionCheater::RMSShowerGradient(std::vector<art::Ptr<recob::SpacePoint> >& sps, const TVector3& ShowerCentre, const TVector3& Direction) const {
 
     //Order the spacepoints
     IShowerTool::GetLArPandoraShowerAlg().OrderShowerSpacePoints(sps,ShowerCentre,Direction);
@@ -239,21 +229,17 @@ namespace ShowerRecoTools {
       ++counter;
     }
 
-    double RMSgradient = (counter*sumxy - sumx*sumy)/(counter*sumx2 - sumx*sumx);
-    return RMSgradient;
-
+    return (counter*sumxy - sumx*sumy)/(counter*sumx2 - sumx*sumx);
   }
 
-  double ShowerDirectionCheater::CalculateRMS(std::vector<float> perps){
-    int counter = 0;
+  double ShowerDirectionCheater::CalculateRMS(const std::vector<float>& perps) const {
+
     double sum  = 0;
     for (const auto &perp : perps){
-      sum= perp*perp;
-      ++counter;
+      sum += perp*perp;
     }
-    double rms = std::sqrt(sum/(counter-1));
-
-    return rms;
+    // No need to bounds check as we have done so already
+    return std::sqrt(sum/(perps.size()-1));
   }
 
 }

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/Cheating/ShowerDirectionCheater_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/Cheating/ShowerDirectionCheater_tool.cc
@@ -37,7 +37,7 @@ namespace ShowerRecoTools {
 
       //fcl
       const art::InputTag fPFParticleLabel;
-      const unsigned fNSegments; //Number of segement to split the shower into the perforam the RMSFlip.
+      const unsigned int fNSegments; //Number of segement to split the shower into the perforam the RMSFlip.
       const bool fRMSFlip;    //Flip the direction by considering the rms.
       const bool fVertexFlip; //Flip the direction by considering the vertex position relative to the center position.
 
@@ -57,7 +57,7 @@ namespace ShowerRecoTools {
     IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools")),
     fLArPandoraShowerCheatingAlg(pset.get<fhicl::ParameterSet>("LArPandoraShowerCheatingAlg")),
     fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel")),
-    fNSegments(pset.get<unsigned>("NSegments")),
+    fNSegments(pset.get<unsigned int>("NSegments")),
     fRMSFlip(pset.get<bool>("RMSFlip")),
     fVertexFlip(pset.get<bool>("VertexFlip")),
     fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel")),
@@ -132,8 +132,8 @@ namespace ShowerRecoTools {
     if (fRMSFlip || fVertexFlip){
 
       // Reset the tree values to defaults
-      rmsGradient = -5.f;
-      vertexDotProduct = -5.f;
+      rmsGradient = std::numeric_limits<float>::lowest();
+      vertexDotProduct = std::numeric_limits<float>::lowest();
 
       //Get the SpacePoints and hits
       art::FindManyP<recob::SpacePoint> fmspp(pfpHandle, Event, fPFParticleLabel);
@@ -149,8 +149,8 @@ namespace ShowerRecoTools {
       }
       std::vector<art::Ptr<recob::SpacePoint> > spacePoints = fmspp.at(pfparticle.key());
 
-      if (spacePoints.empty()) {
-        mf::LogError("ShowerDirectionCheater") << "No spacepoints in shower" << std::endl;
+      if (spacePoints.size() < 3) {
+        mf::LogWarning("ShowerDirectionCheater") << spacePoints.size() << " spacepoints in shower, not calculating direction" << std::endl;
         return 1;
       }
 

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/Cheating/ShowerStartPositionCheater_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/Cheating/ShowerStartPositionCheater_tool.cc
@@ -32,12 +32,11 @@ namespace ShowerRecoTools {
       shower::LArPandoraShowerCheatingAlg fLArPandoraShowerCheatingAlg;
 
       //FCL
-      art::InputTag fPFParticleLabel;
-      art::InputTag fHitModuleLabel;
+      const art::InputTag fPFParticleLabel;
+      const art::InputTag fHitModuleLabel;
 
-      std::string fShowerStartPositionOutputLabel;
-      std::string fTrueParticleOutputLabel;
-
+      const std::string fShowerStartPositionOutputLabel;
+      const std::string fTrueParticleOutputLabel;
   };
 
 
@@ -91,7 +90,12 @@ namespace ShowerRecoTools {
     }
 
     const simb::MCParticle* trueParticle = trueParticles[ShowerTrackInfo.first];
+    if (!trueParticle){
+      mf::LogError("ShowerDirectionCheater") << "True shower not found, returning";
+      return 1;
+    }
 
+    ShowerEleHolder.SetElement(trueParticle,fTrueParticleOutputLabel);
 
     TVector3 trueStartPos = {-999,-999,-999};
     // If the true particle is a photon, we need to be smarter.
@@ -111,8 +115,6 @@ namespace ShowerRecoTools {
 
     TVector3 trueStartPosErr = {-999,-999,-999};
     ShowerEleHolder.SetElement(trueStartPos,trueStartPosErr,fShowerStartPositionOutputLabel);
-
-    ShowerEleHolder.SetElement(trueParticle,fTrueParticleOutputLabel);
 
     return 0;
   }

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/Cheating/ShowerTrackFinderCheater_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/Cheating/ShowerTrackFinderCheater_tool.cc
@@ -33,15 +33,15 @@ namespace ShowerRecoTools {
 
 
       //fcl
-      bool fDebugEVD;
-      art::InputTag fPFParticleLabel;
-      art::InputTag fHitModuleLabel;
+      const bool fDebugEVD;
+      const art::InputTag fPFParticleLabel;
+      const art::InputTag fHitModuleLabel;
 
-      std::string fTrueParticleIntputLabel;
-      std::string fShowerStartPositionInputTag;
-      std::string fShowerDirectionInputTag;
-      std::string fInitialTrackHitsOutputLabel;
-      std::string fInitialTrackSpacePointsOutputLabel;
+      const std::string fTrueParticleIntputLabel;
+      const std::string fShowerStartPositionInputTag;
+      const std::string fShowerDirectionInputTag;
+      const std::string fInitialTrackHitsOutputLabel;
+      const std::string fInitialTrackSpacePointsOutputLabel;
   };
 
 
@@ -102,6 +102,12 @@ namespace ShowerRecoTools {
         return 1;
       }
       trueParticle = trueParticles[ShowerTrackInfo.first];
+      ShowerEleHolder.SetElement(trueParticle,fTrueParticleIntputLabel);
+    }
+
+    if (!trueParticle){
+      mf::LogError("ShowerDirectionCheater") << "True shower not found, returning";
+      return 1;
     }
 
     //This is all based on the shower vertex being known. If it is not lets not do the track
@@ -146,8 +152,9 @@ namespace ShowerRecoTools {
       }
     }
 
-    std::cout << *trueParticle
-      << " with ID: " << trueParticleId<< " and hits: " << trackHits.size() << std::endl;
+    if (trackHits.empty() || trackSpacePoints.empty())
+      mf::LogWarning("ShowerTrackFinderCheater") << "Creating intial track with " <<
+        trackHits.size() << " hits and " << trackSpacePoints.size() << " spacepoints" << std::endl;
 
     ShowerEleHolder.SetElement(trackHits, fInitialTrackHitsOutputLabel);
     ShowerEleHolder.SetElement(trackSpacePoints,fInitialTrackSpacePointsOutputLabel);

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/Cheating/ShowerTrackFinderCheater_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/Cheating/ShowerTrackFinderCheater_tool.cc
@@ -142,12 +142,18 @@ namespace ShowerRecoTools {
     {
       trueParticleIdVec.push_back(trueParticle->TrackId());
     } else {
-      // If we roll up showers, we have no choice but to take all of the hits from the photon
-      trueParticleIdVec.push_back(-trueParticle->TrackId());
-      // If we do not roll up the showers, take all of the primary daughters
-      for (int i=0; i<trueParticle->NumberDaughters(); i++)
+      // To check if we are rolling up showers, check the number of daughters the photon has
+      const int nDaughters = trueParticle->NumberDaughters();
+      if (nDaughters == 0)
       {
-        trueParticleIdVec.push_back(trueParticle->Daughter(i));
+        // If we roll up showers, we have no choice but to take all of the hits from the photon
+        trueParticleIdVec.push_back(-trueParticle->TrackId());
+      } else {
+        // If we do not roll up the showers, take all of the primary daughters
+        for (int i=0; i<nDaughters; i++)
+        {
+          trueParticleIdVec.push_back(trueParticle->Daughter(i));
+        }
       }
     }
 

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h
@@ -73,7 +73,7 @@ namespace ShowerRecoTools{
           reco::shower::ShowerElementHolder& ShowerEleHolder){return 0;}
 
     protected:
-      const shower::LArPandoraShowerAlg& GetLArPandoraShowerAlg() { return fLArPandoraShowerAlg; };
+      const shower::LArPandoraShowerAlg& GetLArPandoraShowerAlg() const { return fLArPandoraShowerAlg; };
 
     private:
 

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerPandoraSlidingFitTrackFinder_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerPandoraSlidingFitTrackFinder_tool.cc
@@ -106,7 +106,7 @@ namespace ShowerRecoTools{
     ShowerEleHolder.GetElement(fInitialTrackSpacePointsInputLabel,spacepoints);
 
     // The track fitter tries to create a traj point from each spacepoint so if we don't have enough
-    // spacepoints we will not get enough tracj points, so let's not even try
+    // spacepoints we will not get enough traj points, so let's not even try
     if (spacepoints.size() < fMinTrajectoryPoints){
       if (fVerbose)
         mf::LogWarning("ShowerPandoraSlidingFitTrackFinder") << "Insufficient space points points to build track: " << spacepoints.size();

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerPandoraSlidingFitTrackFinder_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerPandoraSlidingFitTrackFinder_tool.cc
@@ -105,6 +105,14 @@ namespace ShowerRecoTools{
     std::vector<art::Ptr<recob::SpacePoint> > spacepoints;
     ShowerEleHolder.GetElement(fInitialTrackSpacePointsInputLabel,spacepoints);
 
+    // The track fitter tries to create a traj point from each spacepoint so if we don't have enough
+    // spacepoints we will not get enough tracj points, so let's not even try
+    if (spacepoints.size() < fMinTrajectoryPoints){
+      if (fVerbose)
+        mf::LogWarning("ShowerPandoraSlidingFitTrackFinder") << "Insufficient space points points to build track: " << spacepoints.size();
+      return 1;
+    }
+
     const unsigned int nWirePlanes(fGeom->MaxPlanes());
 
     if (nWirePlanes > 3)


### PR DESCRIPTION
Recently ran a bug was found where the shower track finder cheating tool did not work for photons. This is now fixed in this PR, and should work for both rolled-up and non rolled-up showers.
I also added some additional warnings/info messages to help debug this sort of issue in the future.
I also gave the cheating tools a bit of a tidy up, including moving some code that was shared between different tools into an alg.