### PR TITLE
Add primaryBackground MC process

### DIFF
--- a/larpandora/LArPandoraInterface/LArPandoraInput.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraInput.cxx
@@ -898,6 +898,7 @@ namespace lar_pandora {
     processMap["lambdaInelastic"] = lar_content::MC_PROC_LAMBDA_INELASTIC;
     processMap["muonNuclear"] = lar_content::MC_PROC_MU_NUCLEAR;
     processMap["tInelastic"] = lar_content::MC_PROC_TRITON_INELASTIC;
+    processMap["primaryBackground"] = lar_content::MC_PROC_PRIMARY_BACKGROUND;
   }
 
   //------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Adds the primaryBackground MC process to avoid (harmless) warnings in ProtoDUNE-SP running