### PR TITLE
Accommodate drift-axis != x-axis geometries

### DIFF
--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerPandoraSlidingFitTrackFinder_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerPandoraSlidingFitTrackFinder_tool.cc
@@ -22,6 +22,8 @@
 #include "larpandora/LArPandoraInterface/Detectors/LArPandoraDetectorType.h"
 #include "larpandoracontent/LArHelpers/LArPfoHelper.h"
 
+#include <memory>
+
 namespace ShowerRecoTools {
 
   class ShowerPandoraSlidingFitTrackFinder : IShowerTool {
@@ -121,7 +123,7 @@ namespace ShowerRecoTools {
           << "Insufficient space points points to build track: " << spacepoints.size();
       return 1;
     }
-    lar_pandora::LArPandoraDetectorType* detType(
+    std::unique_ptr<lar_pandora::LArPandoraDetectorType> detType(
       lar_pandora::detector_functions::GetDetectorType());
     // 'wirePitchW` is here used only to provide length scale for binning hits and performing sliding/local linear fits.
     const float wirePitchW(detType->WirePitchW());

--- a/larpandora/LArPandoraEventBuilding/LArPandoraTrackCreation_module.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraTrackCreation_module.cc
@@ -113,7 +113,7 @@ namespace lar_pandora {
     std::unique_ptr<art::Assns<recob::Track, recob::Hit, recob::TrackHitMeta>>
       outputTracksToHitsWithMeta(new art::Assns<recob::Track, recob::Hit, recob::TrackHitMeta>);
 
-    LArPandoraDetectorType* detType(detector_functions::GetDetectorType());
+    std::unique_ptr<LArPandoraDetectorType> detType(detector_functions::GetDetectorType());
     // 'wirePitchW` is here used only to provide length scale for binning hits and performing sliding/local linear fits.
     const float wirePitchW(detType->WirePitchW());
 

--- a/larpandora/LArPandoraInterface/Detectors/DUNEFarDetVDThreeView30DegDriftY.h
+++ b/larpandora/LArPandoraInterface/Detectors/DUNEFarDetVDThreeView30DegDriftY.h
@@ -32,11 +32,11 @@ namespace lar_pandora {
 
   DUNEFarDetVDThreeView30DegDriftY::DUNEFarDetVDThreeView30DegDriftY() :
       VintageLArTPCThreeView(),
-      m_DriftXRotation (0., -1., 0.,
-                        1.,  0., 0.,
-                        0.,  0., 1.),
-      m_InverseDriftXRotation ( 0.,  1., 0.,
-                               -1.,  0., 0.,
+      m_DriftXRotation ( 0.,  1., 0.,
+                        -1.,  0., 0.,
+                         0.,  0., 1.),
+      m_InverseDriftXRotation ( 0., -1., 0.,
+                                1.,  0., 0.,
                                 0.,  0., 1.) {}
 
 

--- a/larpandora/LArPandoraInterface/Detectors/DUNEFarDetVDThreeView30DegDriftY.h
+++ b/larpandora/LArPandoraInterface/Detectors/DUNEFarDetVDThreeView30DegDriftY.h
@@ -17,6 +17,41 @@ namespace lar_pandora {
      */
   class DUNEFarDetVDThreeView30DegDriftY : public VintageLArTPCThreeView {
   public:
+      DUNEFarDetVDThreeView30DegDriftY();
+
+      geo::Point_t RotateToDriftX(const geo::Point_t& globalPoint) const override;
+
+      geo::Point_t UndoRotateToDriftX(const geo::Point_t& localPoint) const override;
+
+  private:
+      geo::Rotation_t m_DriftXRotation;        ///< the rotation to make the drift axis the x-axis
+      geo::Rotation_t m_InverseDriftXRotation; ///< the rotation that undoes the drift==x rotation
   };
+
+  //------------------------------------------------------------------------------------------------------------------------------------------
+
+  DUNEFarDetVDThreeView30DegDriftY::DUNEFarDetVDThreeView30DegDriftY() :
+      VintageLArTPCThreeView(),
+      m_DriftXRotation (0., -1., 0.,
+                        1.,  0., 0.,
+                        0.,  0., 1.),
+      m_InverseDriftXRotation ( 0.,  1., 0.,
+                               -1.,  0., 0.,
+                                0.,  0., 1.) {}
+
+
+  //------------------------------------------------------------------------------------------------------------------------------------------
+
+  geo::Point_t DUNEFarDetVDThreeView30DegDriftY::RotateToDriftX(const geo::Point_t& globalPoint) const
+  {
+      return m_DriftXRotation*globalPoint;
+  }
+
+  //------------------------------------------------------------------------------------------------------------------------------------------
+
+  geo::Point_t DUNEFarDetVDThreeView30DegDriftY::UndoRotateToDriftX(const geo::Point_t& localPoint) const
+  {
+      return m_InverseDriftXRotation*localPoint;
+  }
 
 } // namespace lar_pandora

--- a/larpandora/LArPandoraInterface/Detectors/DUNEFarDetVDThreeView30DegDriftY.h
+++ b/larpandora/LArPandoraInterface/Detectors/DUNEFarDetVDThreeView30DegDriftY.h
@@ -1,0 +1,22 @@
+/**
+ *  @file   larpandora/LArPandoraInterface/Detectors/DUNEFarDetVDThreeView30DegDriftY.h
+ *
+ *  @brief  Detector interface for DUNE's vertical drift, 3 view far detector
+ *
+ *  $Log: $
+ */
+
+#include "larpandora/LArPandoraInterface/Detectors/VintageLArTPCThreeView.h"
+
+#include "larcore/Geometry/Geometry.h"
+
+namespace lar_pandora {
+
+  /**
+     *  @brief  Detector interface DUNE's vertical drift 30 degree view far detector with Y as the drift
+     */
+  class DUNEFarDetVDThreeView30DegDriftY : public VintageLArTPCThreeView {
+  public:
+  };
+
+} // namespace lar_pandora

--- a/larpandora/LArPandoraInterface/Detectors/GetDetectorType.cxx
+++ b/larpandora/LArPandoraInterface/Detectors/GetDetectorType.cxx
@@ -8,6 +8,7 @@
 
 #include "larpandora/LArPandoraInterface/Detectors/GetDetectorType.h"
 #include "larpandora/LArPandoraInterface/Detectors/DUNEFarDetVDThreeView.h"
+#include "larpandora/LArPandoraInterface/Detectors/DUNEFarDetVDThreeView30DegDriftY.h"
 #include "larpandora/LArPandoraInterface/Detectors/ICARUS.h"
 #include "larpandora/LArPandoraInterface/Detectors/LArPandoraDetectorType.h"
 #include "larpandora/LArPandoraInterface/Detectors/ProtoDUNEDualPhase.h"
@@ -23,6 +24,29 @@ namespace lar_pandora {
   LArPandoraDetectorType* detector_functions::GetDetectorType()
   {
     art::ServiceHandle<geo::Geometry const> geo;
+
+    std::set<short int> driftDirectionSet;
+    for (geo::CryostatGeo const& cryo: geo->Iterate<geo::CryostatGeo>()){
+        for (geo::TPCGeo const& TPC: cryo.IterateTPCs()) {
+            (void)driftDirectionSet.insert(TPC.DetectDriftDirection());
+        }
+    }
+    const int driftDirectionCount( (driftDirectionSet.count(1) || driftDirectionSet.count(-1)) +
+                                   (driftDirectionSet.count(2) || driftDirectionSet.count(-2)) +
+                                   (driftDirectionSet.count(3) || driftDirectionSet.count(-3)) +
+                                   driftDirectionSet.count(0) );
+
+    if (driftDirectionCount > 1)
+        throw cet::exception("LArPandora") << "LArPandoraDetectorType::GetDetectorType -- unable to "
+                                              "determine drift direction due to erroneous count.  "
+                                              "Present drift directions: \n"
+                                              "-- +x: " <<  driftDirectionSet.count(1)  << "\n"
+                                              "-- -x: " <<  driftDirectionSet.count(-1) << "\n"
+                                              "-- +y: " <<  driftDirectionSet.count(2)  << "\n"
+                                              "-- -y: " <<  driftDirectionSet.count(-2) << "\n"
+                                              "-- +z: " <<  driftDirectionSet.count(3)  << "\n"
+                                              "-- -z: " <<  driftDirectionSet.count(-3) << "\n"
+                                              "-- ??: " <<  driftDirectionSet.count(0)  << "\n";
 
     const unsigned int nPlanes(geo->MaxPlanes());
     std::set<geo::_plane_proj> planeSet;

--- a/larpandora/LArPandoraInterface/Detectors/GetDetectorType.cxx
+++ b/larpandora/LArPandoraInterface/Detectors/GetDetectorType.cxx
@@ -58,8 +58,12 @@ namespace lar_pandora {
       return new DUNEFarDetVDThreeView; //TODO Address bare pointer
     }
     else if (nPlanes == 3 && planeSet.count(geo::kU) && planeSet.count(geo::kV) &&
-             planeSet.count(geo::kW)) {
+             planeSet.count(geo::kW) && (driftDirectionSet.count(1) || driftDirectionSet.count(-1))) {
       return new VintageLArTPCThreeView;
+    }
+    else if (nPlanes == 3 && planeSet.count(geo::kU) && planeSet.count(geo::kV) &&
+             planeSet.count(geo::kW) && (driftDirectionSet.count(2) || driftDirectionSet.count(-2))) {
+      return new DUNEFarDetVDThreeView30DegDriftY;
     }
     else if (nPlanes == 3 && planeSet.count(geo::kU) && planeSet.count(geo::kV) &&
              planeSet.count(geo::kY)) {

--- a/larpandora/LArPandoraInterface/Detectors/GetDetectorType.cxx
+++ b/larpandora/LArPandoraInterface/Detectors/GetDetectorType.cxx
@@ -31,10 +31,10 @@ namespace lar_pandora {
             (void)driftDirectionSet.insert(TPC.DetectDriftDirection());
         }
     }
-    const int driftDirectionCount( (driftDirectionSet.count(1) || driftDirectionSet.count(-1)) +
-                                   (driftDirectionSet.count(2) || driftDirectionSet.count(-2)) +
-                                   (driftDirectionSet.count(3) || driftDirectionSet.count(-3)) +
-                                   driftDirectionSet.count(0) );
+    const short int driftDirectionCount( (driftDirectionSet.count(1) || driftDirectionSet.count(-1)) +
+                                         (driftDirectionSet.count(2) || driftDirectionSet.count(-2)) +
+                                         (driftDirectionSet.count(3) || driftDirectionSet.count(-3)) +
+                                          driftDirectionSet.count(0) );
 
     if (driftDirectionCount > 1)
         throw cet::exception("LArPandora") << "LArPandoraDetectorType::GetDetectorType -- unable to "

--- a/larpandora/LArPandoraInterface/Detectors/GetDetectorType.cxx
+++ b/larpandora/LArPandoraInterface/Detectors/GetDetectorType.cxx
@@ -21,7 +21,7 @@
 
 namespace lar_pandora {
 
-  LArPandoraDetectorType* detector_functions::GetDetectorType()
+    std::unique_ptr<LArPandoraDetectorType> detector_functions::GetDetectorType()
   {
     art::ServiceHandle<geo::Geometry const> geo;
 
@@ -55,22 +55,22 @@ namespace lar_pandora {
 
     if (nPlanes == 3 && planeSet.count(geo::kU) && planeSet.count(geo::kY) &&
         planeSet.count(geo::kZ)) {
-      return new DUNEFarDetVDThreeView; //TODO Address bare pointer
+      return std::make_unique<DUNEFarDetVDThreeView>();
     }
     else if (nPlanes == 3 && planeSet.count(geo::kU) && planeSet.count(geo::kV) &&
              planeSet.count(geo::kW) && (driftDirectionSet.count(1) || driftDirectionSet.count(-1))) {
-      return new VintageLArTPCThreeView;
+      return std::make_unique<VintageLArTPCThreeView>();
     }
     else if (nPlanes == 3 && planeSet.count(geo::kU) && planeSet.count(geo::kV) &&
              planeSet.count(geo::kW) && (driftDirectionSet.count(2) || driftDirectionSet.count(-2))) {
-      return new DUNEFarDetVDThreeView30DegDriftY;
+      return std::make_unique<DUNEFarDetVDThreeView30DegDriftY>();
     }
     else if (nPlanes == 3 && planeSet.count(geo::kU) && planeSet.count(geo::kV) &&
              planeSet.count(geo::kY)) {
-      return new ICARUS;
+      return std::make_unique<ICARUS>();
     }
     else if (nPlanes == 2 && planeSet.count(geo::kW) && planeSet.count(geo::kY)) {
-      return new ProtoDUNEDualPhase;
+      return std::make_unique<ProtoDUNEDualPhase>();
     }
 
     throw cet::exception("LArPandora") << "LArPandoraDetectorType::GetDetectorType --- unable to "

--- a/larpandora/LArPandoraInterface/Detectors/GetDetectorType.h
+++ b/larpandora/LArPandoraInterface/Detectors/GetDetectorType.h
@@ -1,6 +1,8 @@
 #ifndef LAR_PANDORA_GET_DETECTOR_TYPE_H
 #define LAR_PANDORA_GET_DETECTOR_TYPE_H 1
 
+#include <memory>
+
 namespace lar_pandora {
 
   class LArPandoraDetectorType;
@@ -12,7 +14,7 @@ namespace lar_pandora {
          *
          *  @result The detector type interface
          */
-    LArPandoraDetectorType* GetDetectorType();
+      std::unique_ptr<LArPandoraDetectorType> GetDetectorType();
 
   } // namespace detector_functions
 

--- a/larpandora/LArPandoraInterface/Detectors/LArPandoraDetectorType.h
+++ b/larpandora/LArPandoraInterface/Detectors/LArPandoraDetectorType.h
@@ -104,6 +104,22 @@ namespace lar_pandora {
                              const geo::CryostatID::CryostatID_t cstat) const = 0;
 
     /**
+         *  @brief  Apply a rotation to a point so that the drift axis is parallel to the x-axis
+         *
+         *  @param  globalPoint the point to rotate
+         *  @return the rotated point
+         */
+    virtual geo::Point_t RotateToDriftX(const geo::Point_t& globalPoint) const = 0;
+
+    /**
+         *  @brief  Undo a RotateToDriftX rotation
+         *
+         *  @param  localPoint the point to rotate
+         *  @return the rotated point
+         */
+    virtual geo::Point_t UndoRotateToDriftX(const geo::Point_t& localPoint) const = 0;
+
+    /**
              *  @brief  Check whether a gap size is small enough to be registered as a detector gap
              *
              *  @param  gaps a cartesean vector holding gap sizes between adjacent TPCs

--- a/larpandora/LArPandoraInterface/Detectors/VintageLArTPCThreeView.h
+++ b/larpandora/LArPandoraInterface/Detectors/VintageLArTPCThreeView.h
@@ -51,6 +51,10 @@ namespace lar_pandora {
     virtual float WireAngleW(const geo::TPCID::TPCID_t tpc,
                              const geo::CryostatID::CryostatID_t cstat) const override;
 
+    virtual geo::Point_t RotateToDriftX(const geo::Point_t& globalPoint) const override;
+
+    virtual geo::Point_t UndoRotateToDriftX(const geo::Point_t& localPoint) const override;
+
     virtual bool CheckDetectorGapSize(const geo::Vector_t& gaps,
                                       const geo::Vector_t& deltas,
                                       const float maxDisplacement) const override;
@@ -165,6 +169,20 @@ namespace lar_pandora {
   {
     return detector_functions::WireAngle(
       this->TargetViewW(tpc, cstat), tpc, cstat, m_LArSoftGeometry);
+  }
+
+  //------------------------------------------------------------------------------------------------------------------------------------------
+
+  inline geo::Point_t VintageLArTPCThreeView::RotateToDriftX(const geo::Point_t& globalPoint) const
+  {
+    return globalPoint;
+  }
+
+  //------------------------------------------------------------------------------------------------------------------------------------------
+
+  inline geo::Point_t VintageLArTPCThreeView::UndoRotateToDriftX(const geo::Point_t& localPoint) const
+  {
+    return localPoint;
   }
 
   //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandora/LArPandoraInterface/LArPandoraGeometry.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraGeometry.cxx
@@ -18,6 +18,7 @@
 #include "larpandora/LArPandoraInterface/Detectors/LArPandoraDetectorType.h"
 
 #include <iomanip>
+#include <memory>
 #include <set>
 
 namespace lar_pandora {
@@ -34,7 +35,7 @@ namespace lar_pandora {
     LArDriftVolumeList driftVolumeList;
     LArPandoraGeometry::LoadGeometry(driftVolumeList, useActiveBoundingBox);
 
-    LArPandoraDetectorType* detType(detector_functions::GetDetectorType());
+    std::unique_ptr<LArPandoraDetectorType> detType(detector_functions::GetDetectorType());
 
     for (LArDriftVolumeList::const_iterator iter1 = driftVolumeList.begin(),
                                             iterEnd1 = driftVolumeList.end();
@@ -234,7 +235,7 @@ namespace lar_pandora {
 
     // Pandora requires three independent images, and ability to correlate features between images (via wire angles and transformation plugin).
     art::ServiceHandle<geo::Geometry const> theGeometry;
-    LArPandoraDetectorType* detType(detector_functions::GetDetectorType());
+    std::unique_ptr<LArPandoraDetectorType> detType(detector_functions::GetDetectorType());
     const float wirePitchU(detType->WirePitchU());
     const float wirePitchV(detType->WirePitchV());
     const float wirePitchW(detType->WirePitchW());

--- a/larpandora/LArPandoraInterface/LArPandoraGeometry.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraGeometry.cxx
@@ -258,29 +258,32 @@ namespace lar_pandora {
         const float wireAngleV(detType->WireAngleV(itpc1, icstat));
         const float wireAngleW(detType->WireAngleW(itpc1, icstat));
 
-        auto const worldCoord1 = theTpc1.GetCenter();
+        auto const worldCoord1 = detType->RotateToDriftX(theTpc1.GetCenter());
+        geo::Point_t widths1(theTpc1.ActiveHalfWidth(), theTpc1.ActiveHalfHeight(), theTpc1.ActiveLength());
+        widths1 = detType->RotateToDriftX(widths1);
+        widths1.SetCoordinates(std::abs(widths1.X()), std::abs(widths1.Y()), std::abs(widths1.Z()));
 
         float driftMinX(useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MinX() :
-                                               (worldCoord1.X() - theTpc1.ActiveHalfWidth()));
+                                               (worldCoord1.X() - widths1.X()));
         float driftMaxX(useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MaxX() :
-                                               (worldCoord1.X() + theTpc1.ActiveHalfWidth()));
+                                               (worldCoord1.X() + widths1.X()));
         float driftMinY(useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MinY() :
-                                               (worldCoord1.Y() - theTpc1.ActiveHalfHeight()));
+                                               (worldCoord1.Y() - widths1.Y()));
         float driftMaxY(useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MaxY() :
-                                               (worldCoord1.Y() + theTpc1.ActiveHalfHeight()));
+                                               (worldCoord1.Y() + widths1.Y()));
         float driftMinZ(useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MinZ() :
-                                               (worldCoord1.Z() - 0.5f * theTpc1.ActiveLength()));
+                                               (worldCoord1.Z() - 0.5f * widths1.Z()));
         float driftMaxZ(useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MaxZ() :
-                                               (worldCoord1.Z() + 0.5f * theTpc1.ActiveLength()));
+                                               (worldCoord1.Z() + 0.5f * widths1.Z()));
 
         const double min1(
           useActiveBoundingBox ?
             (0.5 * (driftMinX + driftMaxX) - 0.25 * std::fabs(driftMaxX - driftMinX)) :
-            (worldCoord1.X() - 0.5 * theTpc1.ActiveHalfWidth()));
+            (worldCoord1.X() - 0.5 * widths1.X()));
         const double max1(
           useActiveBoundingBox ?
             (0.5 * (driftMinX + driftMaxX) + 0.25 * std::fabs(driftMaxX - driftMinX)) :
-            (worldCoord1.X() + 0.5 * theTpc1.ActiveHalfWidth()));
+            (worldCoord1.X() + 0.5 * widths1.X()));
 
         const bool isPositiveDrift(theTpc1.DriftDirection() == geo::kPosX);
 
@@ -313,23 +316,27 @@ namespace lar_pandora {
           if (dThetaU > maxDeltaTheta || dThetaV > maxDeltaTheta || dThetaW > maxDeltaTheta)
             continue;
 
-          auto const worldCoord2 = theTpc2.GetCenter();
+          auto const worldCoord2 = detType->RotateToDriftX(theTpc2.GetCenter());
+          geo::Point_t widths2(theTpc2.ActiveHalfWidth(), theTpc2.ActiveHalfHeight(), theTpc2.ActiveLength());
+          widths2 = detType->RotateToDriftX(widths2);
+          widths2.SetCoordinates(std::abs(widths2.X()), std::abs(widths2.Y()), std::abs(widths2.Z()));
+
 
           const float driftMinX2(useActiveBoundingBox ?
                                    theTpc2.ActiveBoundingBox().MinX() :
-                                   (worldCoord2.X() - theTpc2.ActiveHalfWidth()));
+                                   (worldCoord2.X() - widths2.X()));
           const float driftMaxX2(useActiveBoundingBox ?
                                    theTpc2.ActiveBoundingBox().MaxX() :
-                                   (worldCoord2.X() + theTpc2.ActiveHalfWidth()));
+                                   (worldCoord2.X() + widths2.X()));
 
           const double min2(
             useActiveBoundingBox ?
               (0.5 * (driftMinX2 + driftMaxX2) - 0.25 * std::fabs(driftMaxX2 - driftMinX2)) :
-              (worldCoord2.X() - 0.5 * theTpc2.ActiveHalfWidth()));
+              (worldCoord2.X() - 0.5 * widths2.X()));
           const double max2(
             useActiveBoundingBox ?
               (0.5 * (driftMinX2 + driftMaxX2) + 0.25 * std::fabs(driftMaxX2 - driftMinX2)) :
-              (worldCoord2.X() + 0.5 * theTpc2.ActiveHalfWidth()));
+              (worldCoord2.X() + 0.5 * widths2.X()));
 
           if ((min2 > max1) || (min1 > max2)) continue;
 
@@ -338,16 +345,16 @@ namespace lar_pandora {
 
           const float driftMinY2(useActiveBoundingBox ?
                                    theTpc2.ActiveBoundingBox().MinY() :
-                                   (worldCoord2.Y() - theTpc2.ActiveHalfHeight()));
+                                   (worldCoord2.Y() - widths2.Y()));
           const float driftMaxY2(useActiveBoundingBox ?
                                    theTpc2.ActiveBoundingBox().MaxY() :
-                                   (worldCoord2.Y() + theTpc2.ActiveHalfHeight()));
+                                   (worldCoord2.Y() + widths2.Y()));
           const float driftMinZ2(useActiveBoundingBox ?
                                    theTpc2.ActiveBoundingBox().MinZ() :
-                                   (worldCoord2.Z() - 0.5f * theTpc2.ActiveLength()));
+                                   (worldCoord2.Z() - 0.5f * widths2.Z()));
           const float driftMaxZ2(useActiveBoundingBox ?
                                    theTpc2.ActiveBoundingBox().MaxZ() :
-                                   (worldCoord2.Z() + 0.5f * theTpc2.ActiveLength()));
+                                   (worldCoord2.Z() + 0.5f * widths2.Z()));
 
           driftMinX = std::min(driftMinX, driftMinX2);
           driftMaxX = std::max(driftMaxX, driftMaxX2);

--- a/larpandora/LArPandoraInterface/LArPandoraInput.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraInput.cxx
@@ -95,6 +95,12 @@ namespace lar_pandora {
       const double y0_cm(xyz.Y());
       const double z0_cm(xyz.Z());
 
+      if (hit_View == detType->TargetViewW(hit_WireID.TPC, hit_WireID.Cryostat)){
+          auto const xyznorot = theGeometry->Wire(hit_WireID).GetCenter();
+          std::cout<<"norot: " << "  " << xpos_cm << "  " << xyznorot.X() << "  " << xyznorot.Y() << "  " << xyznorot.z() << std::endl;
+          std::cout<<"wirot: " << "  " << xpos_cm << "  " << xyz.X() << "  " << xyz.Y() << "  " << xyz.z() << std::endl;
+
+      }
       // Get other hit properties here
       const double wire_pitch_cm(theGeometry->WirePitch(hit_View)); // cm
       const double mips(LArPandoraInput::GetMips(detProp, settings, hit_Charge, hit_View));

--- a/larpandora/LArPandoraInterface/LArPandoraInput.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraInput.cxx
@@ -89,7 +89,7 @@ namespace lar_pandora {
                     hit_TimeStart, hit_WireID.Plane, hit_WireID.TPC, hit_WireID.Cryostat)));
 
       // Get hit Y and Z coordinates, based on central position of wire
-      auto const xyz = theGeometry->Wire(hit_WireID).GetCenter();
+      auto const xyz = detType->RotateToDriftX(theGeometry->Wire(hit_WireID).GetCenter());
       const double y0_cm(xyz.Y());
       const double z0_cm(xyz.Z());
 

--- a/larpandora/LArPandoraInterface/LArPandoraInput.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraInput.cxx
@@ -38,6 +38,7 @@
 #include "messagefacility/MessageLogger/MessageLogger.h"
 
 #include <limits>
+#include <memory>
 #include <utility>
 
 namespace lar_pandora {
@@ -59,7 +60,7 @@ namespace lar_pandora {
 
     art::ServiceHandle<geo::Geometry const> theGeometry;
     auto const detProp = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(e);
-    LArPandoraDetectorType* detType(detector_functions::GetDetectorType());
+    std::unique_ptr<LArPandoraDetectorType> detType(detector_functions::GetDetectorType());
 
     // Loop over ART hits
     int hitCounter(settings.m_hitCounterOffset);
@@ -90,6 +91,7 @@ namespace lar_pandora {
 
       // Get hit Y and Z coordinates, based on central position of wire
       auto const xyz = detType->RotateToDriftX(theGeometry->Wire(hit_WireID).GetCenter());
+
       const double y0_cm(xyz.Y());
       const double z0_cm(xyz.Z());
 
@@ -241,7 +243,7 @@ namespace lar_pandora {
   {
     //ATTN - Unlike SP, DP detector gaps are not in the drift direction
     art::ServiceHandle<geo::Geometry const> theGeometry;
-    LArPandoraDetectorType* detType(detector_functions::GetDetectorType());
+    std::unique_ptr<LArPandoraDetectorType> detType(detector_functions::GetDetectorType());
 
     mf::LogDebug("LArPandora") << " *** LArPandoraInput::CreatePandoraDetectorGaps(...) *** "
                                << std::endl;
@@ -297,7 +299,7 @@ namespace lar_pandora {
     const lariov::ChannelStatusProvider& channelStatus(
       art::ServiceHandle<lariov::ChannelStatusService const>()->GetProvider());
 
-    LArPandoraDetectorType* detType(detector_functions::GetDetectorType());
+    std::unique_ptr<LArPandoraDetectorType> detType(detector_functions::GetDetectorType());
 
     for (auto const& plane : theGeometry->Iterate<geo::PlaneGeo>()) {
       const float halfWirePitch(0.5f * theGeometry->WirePitch(plane.View()));

--- a/larpandora/LArPandoraInterface/LArPandoraOutput.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraOutput.cxx
@@ -36,6 +36,7 @@
 #include <iostream>
 #include <iterator>
 #include <limits>
+#include <memory>
 #include <numeric> // std::iota()
 
 namespace lar_pandora {
@@ -119,7 +120,7 @@ namespace lar_pandora {
     LArPandoraOutput::GetPandoraToArtHitMap(
       clusterList, threeDHitList, idToHitMap, pandoraHitToArtHitMap);
 
-    LArPandoraDetectorType* detType(detector_functions::GetDetectorType());
+    std::unique_ptr<LArPandoraDetectorType> detType(detector_functions::GetDetectorType());
 
     // Build the ART outputs from the pandora objects
     LArPandoraOutput::BuildVertices(vertexVector, outputVertices, detType);
@@ -582,7 +583,7 @@ namespace lar_pandora {
 
   void LArPandoraOutput::BuildVertices(const pandora::VertexVector& vertexVector,
                                        VertexCollection& outputVertices,
-                                       const LArPandoraDetectorType* detType)
+                                       const std::unique_ptr<LArPandoraDetectorType>& detType)
   {
     for (size_t vertexId = 0; vertexId < vertexVector.size(); ++vertexId)
       outputVertices->push_back(LArPandoraOutput::BuildVertex(vertexVector.at(vertexId), vertexId, detType));
@@ -596,7 +597,7 @@ namespace lar_pandora {
                                           const CaloHitToArtHitMap& pandoraHitToArtHitMap,
                                           SpacePointCollection& outputSpacePoints,
                                           SpacePointToHitCollection& outputSpacePointsToHits,
-                                          const LArPandoraDetectorType* detType)
+                                          const std::unique_ptr<LArPandoraDetectorType>& detType)
   {
     pandora::CaloHitVector threeDHitVector;
     threeDHitVector.insert(threeDHitVector.end(), threeDHitList.begin(), threeDHitList.end());
@@ -967,7 +968,7 @@ namespace lar_pandora {
 
   recob::Vertex LArPandoraOutput::BuildVertex(const pandora::Vertex* const pVertex,
                                               const size_t vertexId,
-                                              const LArPandoraDetectorType* detType)
+                                              const std::unique_ptr<LArPandoraDetectorType>& detType)
   {
     geo::Point_t pos = {
       pVertex->GetPosition().GetX(), pVertex->GetPosition().GetY(), pVertex->GetPosition().GetZ()};
@@ -1142,7 +1143,7 @@ namespace lar_pandora {
 
   recob::SpacePoint LArPandoraOutput::BuildSpacePoint(const pandora::CaloHit* const pCaloHit,
                                                       const size_t spacePointId,
-                                                      const LArPandoraDetectorType* detType)
+                                                      const std::unique_ptr<LArPandoraDetectorType>& detType)
   {
     if (pandora::TPC_3D != pCaloHit->GetHitType())
       throw cet::exception("LArPandora")

--- a/larpandora/LArPandoraInterface/LArPandoraOutput.h
+++ b/larpandora/LArPandoraInterface/LArPandoraOutput.h
@@ -21,6 +21,7 @@ namespace cluster {
 
 #include "larpandora/LArPandoraInterface/ILArPandora.h"
 #include "larpandora/LArPandoraInterface/LArPandoraHelper.h"
+#include "larpandora/LArPandoraInterface/Detectors/LArPandoraDetectorType.h"
 
 #include "lardataobj/AnalysisBase/T0.h"
 #include "lardataobj/RecoBase/Cluster.h"
@@ -289,9 +290,11 @@ namespace lar_pandora {
      *
      *  @param  vertexVector the input list of pandora vertices
      *  @param  outputVertices the output vector of ART vertices
+     *  @param  detType Underlying detector specifics
      */
     static void BuildVertices(const pandora::VertexVector& vertexVector,
-                              VertexCollection& outputVertices);
+                              VertexCollection& outputVertices, 
+                              const LArPandoraDetectorType* detType);
 
     /**
      *  @brief  Convert pandora 3D hits to ART spacepoints and add them to the output vector
@@ -302,13 +305,15 @@ namespace lar_pandora {
      *  @param  pandoraHitToArtHitMap the input mapping from pandora hits to ART hits
      *  @param  outputSpacePoints the output vector of spacepoints
      *  @param  outputSpacePointsToHits the output associations between spacepoints and hits
+     *  @param  detType Underlying detector specifics
      */
     static void BuildSpacePoints(const art::Event& event,
                                  const std::string& instanceLabel,
                                  const pandora::CaloHitList& threeDHitList,
                                  const CaloHitToArtHitMap& pandoraHitToArtHitMap,
                                  SpacePointCollection& outputSpacePoints,
-                                 SpacePointToHitCollection& outputSpacePointsToHits);
+                                 SpacePointToHitCollection& outputSpacePointsToHits,
+                                 const LArPandoraDetectorType* detType);
 
     /**
      *  @brief  Convert pandora 2D clusters to ART clusters and add them to the output vector
@@ -476,21 +481,25 @@ namespace lar_pandora {
      *
      *  @param  pVertex the input vertex
      *  @param  vertexId the id of the vertex to produce
+     *  @param  detType Underlying detector specifics
      *
      *  @param  the ART vertex
      */
-    static recob::Vertex BuildVertex(const pandora::Vertex* const pVertex, const size_t vertexId);
+    static recob::Vertex BuildVertex(const pandora::Vertex* const pVertex, const size_t vertexId,
+                                     const LArPandoraDetectorType* detType);
 
     /**
      *  @brief  Convert from a pandora 3D hit to an ART spacepoint
      *
      *  @param  pCaloHit the input hit
      *  @param  spacePointId the id of the space-point to produce
+     *  @param  detType Underlying detector specifics
      *
      *  @param  the ART spacepoint
      */
     static recob::SpacePoint BuildSpacePoint(const pandora::CaloHit* const pCaloHit,
-                                             const size_t spacePointId);
+                                             const size_t spacePointId,
+                                             const LArPandoraDetectorType* detType);
 
     /**
      *  @brief  Collect a sorted list of all 2D hits in a cluster

--- a/larpandora/LArPandoraInterface/LArPandoraOutput.h
+++ b/larpandora/LArPandoraInterface/LArPandoraOutput.h
@@ -294,7 +294,7 @@ namespace lar_pandora {
      */
     static void BuildVertices(const pandora::VertexVector& vertexVector,
                               VertexCollection& outputVertices, 
-                              const LArPandoraDetectorType* detType);
+                              const std::unique_ptr<LArPandoraDetectorType>& detType);
 
     /**
      *  @brief  Convert pandora 3D hits to ART spacepoints and add them to the output vector
@@ -313,7 +313,7 @@ namespace lar_pandora {
                                  const CaloHitToArtHitMap& pandoraHitToArtHitMap,
                                  SpacePointCollection& outputSpacePoints,
                                  SpacePointToHitCollection& outputSpacePointsToHits,
-                                 const LArPandoraDetectorType* detType);
+                                 const std::unique_ptr<LArPandoraDetectorType>& detType);
 
     /**
      *  @brief  Convert pandora 2D clusters to ART clusters and add them to the output vector
@@ -486,7 +486,7 @@ namespace lar_pandora {
      *  @param  the ART vertex
      */
     static recob::Vertex BuildVertex(const pandora::Vertex* const pVertex, const size_t vertexId,
-                                     const LArPandoraDetectorType* detType);
+                                     const std::unique_ptr<LArPandoraDetectorType>& detType);
 
     /**
      *  @brief  Convert from a pandora 3D hit to an ART spacepoint
@@ -499,7 +499,7 @@ namespace lar_pandora {
      */
     static recob::SpacePoint BuildSpacePoint(const pandora::CaloHit* const pCaloHit,
                                              const size_t spacePointId,
-                                             const LArPandoraDetectorType* detType);
+                                             const std::unique_ptr<LArPandoraDetectorType>& detType);
 
     /**
      *  @brief  Collect a sorted list of all 2D hits in a cluster


### PR DESCRIPTION
Such geometries are accommodated by rotating the input coordinates of the wires/strips to realign x as the drift axis; the pat rec algs then continue to operate under the belief that x==drift.  The inverse rotations are applied to the recob::SpacePoints and recob::Vertices at point of creation, and are then returned to ART/LArSoft.

Code can be broken down into a few areas:
 - Include rotation and inverse rotation functions in the LArPandoraDetectorType class + derived classes
 - Include derived class for the Drift Y 30 deg VDFD (and ProtoDUNE) geometry
 - Update GetDetectorType to recognise the Drift Y 30 deg VDFD geometry
 - Update LArPandoraGeometry, LArPandoraInput and LArPandoraOutput to make use of the functions
 - BONUS: Convert the entire interface to unique_ptrs rather than raw pointers
 
 This code has only been tested using couts so far, but the couts do suggest that the rotations and inverse rotations are being applied sensibly.
 
 More testing is needed, but I don't anticipate major changes so the PR review can go ahead.