### PR TITLE
Add nuance code for supernova interactions

### DIFF
--- a/larpandora/LArPandoraInterface/LArPandoraInput.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraInput.cxx
@@ -423,7 +423,10 @@ namespace lar_pandora {
         lar_content::LArMCParticleParameters mcParticleParameters;
 
         try {
-          mcParticleParameters.m_nuanceCode = neutrino.InteractionType();
+          if (truth->Origin() == simb::kSuperNovaNeutrino)
+            mcParticleParameters.m_nuanceCode = 4000;
+          else
+            mcParticleParameters.m_nuanceCode = neutrino.InteractionType();
           mcParticleParameters.m_process = lar_content::MC_PROC_INCIDENT_NU;
           mcParticleParameters.m_energy = neutrino.Nu().E();
           mcParticleParameters.m_momentum =
@@ -549,6 +552,9 @@ namespace lar_pandora {
       }
       else if (simb::kSingleParticle == origin) {
         nuanceCode = 2000;
+      }
+      else if (simb::kSuperNovaNeutrino == origin) {
+        nuanceCode = 4000;
       }
 
       // Create 3D Pandora MC Particle


### PR DESCRIPTION
The nuance code is used in decision making e.g. does this particle come from a neutrino interaction or a cosmic ray.
MARLEY sets nuance codes to 0, which breaks a lot of the logic in the decision making.

I'm adding a nuance code override for supernova origin particles (code==4000).

Matt confirmed that this ran OK is his test setup so this can now be merged.