### PR TITLE
Override plane-by-plane the result from the trajectory-based dE/dx tool

### DIFF
--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrajPointdEdx_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrajPointdEdx_tool.cc
@@ -63,15 +63,18 @@ namespace ShowerRecoTools {
     bool fUseMedian;        //Use the median value as the dEdx rather than the mean.
     bool fCutStartPosition; //Remove hits using MinDistCutOff from the vertex as well.
 
-    bool fT0Correct;       // Whether to look for a T0 associated to the PFP
-    bool fSCECorrectPitch; // Whether to correct the "squeezing" of pitch, requires corrected input
+    bool fT0Correct;       //Whether to look for a T0 associated to the PFP
+    bool fSCECorrectPitch; //Whether to correct the "squeezing" of pitch, requires corrected input
     bool
-      fSCECorrectEField;   // Whether to use the local electric field, from SpaceChargeService, in recombination calc.
+      fSCECorrectEField;   //Whether to use the local electric field, from SpaceChargeService, in recombination calc.
     bool
-      fSCEInputCorrected;  // Whether the input has already been corrected for spatial SCE distortions
+      fSCEInputCorrected;  //Whether the input has already been corrected for spatial SCE distortions
 
-    bool fSumHitSnippets;  // Whether to treat hits individually or only one hit per snippet
-    bool fOverrideByPlane; // Whether to override plane-by-plane the results from a previous tool writing on the same label
+    bool fSumHitSnippets;      //Whether to treat hits individually or only one hit per snippet
+    int fResultsOverrideMode;  //How results from a previous tool writing on the same tool are overridden
+    //0: always override previous results
+    //1: override plane-by-plane
+    //2: override only if all three planes are well-defined
 
     art::InputTag fPFParticleLabel;
     int fVerbose;
@@ -101,7 +104,7 @@ namespace ShowerRecoTools {
     , fSCECorrectEField(pset.get<bool>("SCECorrectEField"))
     , fSCEInputCorrected(pset.get<bool>("SCEInputCorrected"))
     , fSumHitSnippets(pset.get<bool>("SumHitSnippets"))
-    , fOverrideByPlane(pset.get<bool>("OverrideByPlane"))
+    , fResultsOverrideMode(pset.get<int>("ResultsOverrideMode"))
     , fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel"))
     , fVerbose(pset.get<int>("Verbose"))
     , fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel"))
@@ -392,47 +395,84 @@ namespace ShowerRecoTools {
       }
     }
 
-    //Override the tool result plane-by-plane
-    if (fOverrideByPlane) {
+    //Get results from the same label, if set by a previous tool of the same type
+    std::vector<double> dEdx_val_previousTool;
+    ShowerEleHolder.GetElement(fShowerdEdxOutputLabel, dEdx_val_previousTool);
+    if (fVerbose > 2) {
+      std::cout << "Result from previous dEdx tool..." << std::endl;
+      for (unsigned int plane = 0; plane < dEdx_val_previousTool.size(); plane++) {
+        std::cout << "Plane: " << plane << " with dEdx: " << dEdx_val_previousTool[plane] << std::endl;
+      }
+    } 
 
-      //Get results from the same label, if set by a previous tool of the same type
-      std::vector<double> dEdx_val_previousTool;
-      ShowerEleHolder.GetElement(fShowerdEdxOutputLabel, dEdx_val_previousTool);
-      if (fVerbose > 2) {
-        std::cout << "Result from previous dEdx tool..." << std::endl;
-        for (unsigned int plane = 0; plane < dEdx_val_previousTool.size(); plane++) {
-          std::cout << "Plane: " << plane << " with dEdx: " << dEdx_val_previousTool[plane] << std::endl;
-        }
-      } 
+    //Choose how to override results from the previous tool
+    switch (fResultsOverrideMode) {
 
-      std::vector<double> dEdx_val_overriddenPerPlane(dEdx_val);
+      //Always override previous results
+      //This will keep the previous result only if the current tool fails on all planes
+      case 0:
 
-      for (unsigned int plane = 0; plane < dEdx_val.size(); plane++) {
-        //If the current tool fails, just retain plane-by-plane the result from the previous tool
-        if (dEdx_val[plane] < 0.) {
-          dEdx_val_overriddenPerPlane[plane] = dEdx_val_previousTool[plane];
-          if (fVerbose > 2) {
-            std::cout << "This tool failed in plane " << plane << " and I am keeping the previous value" << std::endl;
-            std::cout << "Current value: " << dEdx_val[plane] << std::endl;
-            std::cout << "Chosen value:  " << dEdx_val_overriddenPerPlane[plane] << std::endl;
+        if (fVerbose > 1) {
+          std::cout << "Always overriding the previous result." << std::endl;
+        } 
+
+        ShowerEleHolder.SetElement(dEdx_val, dEdx_valErr, fShowerdEdxOutputLabel);
+        ShowerEleHolder.SetElement(best_plane, fShowerBestPlaneOutputLabel);
+        ShowerEleHolder.SetElement(dEdx_vec_cut, fShowerdEdxVecOutputLabel);
+
+        break;
+
+      //Override plane-by-plane
+      case 1:
+
+        if (fVerbose > 1) {
+          std::cout << "Overriding the previous result plane-by-plane." << std::endl;
+        } 
+
+        std::vector<double> dEdx_val_overriddenPerPlane(dEdx_val);
+        for (unsigned int plane = 0; plane < dEdx_val.size(); plane++) {
+          //If the current tool fails, just retain plane-by-plane the result from the previous tool
+          if (dEdx_val[plane] < 0.) {
+            dEdx_val_overriddenPerPlane[plane] = dEdx_val_previousTool[plane];
+            if (fVerbose > 2) {
+              std::cout << "This tool failed in plane " << plane << " and I am keeping the previous value" << std::endl;
+              std::cout << "Current value: " << dEdx_val[plane] << std::endl;
+              std::cout << "Chosen value:  " << dEdx_val_overriddenPerPlane[plane] << std::endl;
+            }
+          }
+          else {
+            dEdx_val_overriddenPerPlane[plane] = dEdx_val[plane];
           }
         }
-        else {
-          dEdx_val_overriddenPerPlane[plane] = dEdx_val[plane];
+
+        ShowerEleHolder.SetElement(dEdx_val_overriddenPerPlane, dEdx_valErr, fShowerdEdxOutputLabel);
+        ShowerEleHolder.SetElement(best_plane, fShowerBestPlaneOutputLabel);
+        ShowerEleHolder.SetElement(dEdx_vec_cut, fShowerdEdxVecOutputLabel);
+        break;
+
+      //Override only if all three planes are well-defined
+      case 2:
+
+        if (fVerbose > 1) {
+          std::cout << "Only overriding if all three planes are well-defined." << std::endl;
+        } 
+
+        if (dEdx_val[0] > 0. &&
+            dEdx_val[1] > 0. &&
+            dEdx_val[2] > 0.) {
+          ShowerEleHolder.SetElement(dEdx_val, dEdx_valErr, fShowerdEdxOutputLabel);
+          ShowerEleHolder.SetElement(best_plane, fShowerBestPlaneOutputLabel);
+          ShowerEleHolder.SetElement(dEdx_vec_cut, fShowerdEdxVecOutputLabel);
         }
-      }
+        else {
+          ShowerEleHolder.SetElement(dEdx_val_previousTool, dEdx_valErr, fShowerdEdxOutputLabel);
+          ShowerEleHolder.SetElement(best_plane, fShowerBestPlaneOutputLabel);
+          ShowerEleHolder.SetElement(dEdx_vec_cut, fShowerdEdxVecOutputLabel);  
+        }
 
-      //Need to sort out errors sensibly.
-      ShowerEleHolder.SetElement(dEdx_val_overriddenPerPlane, dEdx_valErr, fShowerdEdxOutputLabel);
-      ShowerEleHolder.SetElement(best_plane, fShowerBestPlaneOutputLabel);
-      ShowerEleHolder.SetElement(dEdx_vec_cut, fShowerdEdxVecOutputLabel);
-      return 0;
+        break;
     }
-
-    //Need to sort out errors sensibly.
-    ShowerEleHolder.SetElement(dEdx_val, dEdx_valErr, fShowerdEdxOutputLabel);
-    ShowerEleHolder.SetElement(best_plane, fShowerBestPlaneOutputLabel);
-    ShowerEleHolder.SetElement(dEdx_vec_cut, fShowerdEdxVecOutputLabel);
+    
     return 0;
   }
 

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrajPointdEdx_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrajPointdEdx_tool.cc
@@ -410,10 +410,10 @@ namespace ShowerRecoTools {
 
       //Always override previous results
       //This will keep the previous result only if the current tool fails on all planes
-      case 0:
+      case 0: {
 
         if (fVerbose > 1) {
-          std::cout << "Always overriding the previous result." << std::endl;
+          std::cout << "Always overriding the previous result" << std::endl;
         } 
 
         ShowerEleHolder.SetElement(dEdx_val, dEdx_valErr, fShowerdEdxOutputLabel);
@@ -421,12 +421,13 @@ namespace ShowerRecoTools {
         ShowerEleHolder.SetElement(dEdx_vec_cut, fShowerdEdxVecOutputLabel);
 
         break;
+      }
 
       //Override plane-by-plane
-      case 1:
+      case 1: {
 
         if (fVerbose > 1) {
-          std::cout << "Overriding the previous result plane-by-plane." << std::endl;
+          std::cout << "Overriding the previous result plane-by-plane" << std::endl;
         } 
 
         std::vector<double> dEdx_val_overriddenPerPlane(dEdx_val);
@@ -449,12 +450,13 @@ namespace ShowerRecoTools {
         ShowerEleHolder.SetElement(best_plane, fShowerBestPlaneOutputLabel);
         ShowerEleHolder.SetElement(dEdx_vec_cut, fShowerdEdxVecOutputLabel);
         break;
+      }
 
       //Override only if all three planes are well-defined
-      case 2:
+      case 2: {
 
         if (fVerbose > 1) {
-          std::cout << "Only overriding if all three planes are well-defined." << std::endl;
+          std::cout << "Only overriding if all three planes are well-defined" << std::endl;
         } 
 
         if (dEdx_val[0] > 0. &&
@@ -471,6 +473,7 @@ namespace ShowerRecoTools {
         }
 
         break;
+      }
     }
     
     return 0;

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrajPointdEdx_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrajPointdEdx_tool.cc
@@ -66,11 +66,12 @@ namespace ShowerRecoTools {
     bool fT0Correct;       // Whether to look for a T0 associated to the PFP
     bool fSCECorrectPitch; // Whether to correct the "squeezing" of pitch, requires corrected input
     bool
-      fSCECorrectEField; // Whether to use the local electric field, from SpaceChargeService, in recombination calc.
+      fSCECorrectEField;   // Whether to use the local electric field, from SpaceChargeService, in recombination calc.
     bool
-      fSCEInputCorrected; // Whether the input has already been corrected for spatial SCE distortions
+      fSCEInputCorrected;  // Whether the input has already been corrected for spatial SCE distortions
 
-    bool fSumHitSnippets; // Whether to treat hits individually or only one hit per snippet
+    bool fSumHitSnippets;  // Whether to treat hits individually or only one hit per snippet
+    bool fOverrideByPlane; // Whether to override plane-by-plane the results from a previous tool writing on the same label
 
     art::InputTag fPFParticleLabel;
     int fVerbose;
@@ -100,6 +101,7 @@ namespace ShowerRecoTools {
     , fSCECorrectEField(pset.get<bool>("SCECorrectEField"))
     , fSCEInputCorrected(pset.get<bool>("SCEInputCorrected"))
     , fSumHitSnippets(pset.get<bool>("SumHitSnippets"))
+    , fOverrideByPlane(pset.get<bool>("OverrideByPlane"))
     , fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel"))
     , fVerbose(pset.get<int>("Verbose"))
     , fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel"))
@@ -388,6 +390,43 @@ namespace ShowerRecoTools {
           }
         }
       }
+    }
+
+    //Override the tool result plane-by-plane
+    if (fOverrideByPlane) {
+
+      //Get results from the same label, if set by a previous tool of the same type
+      std::vector<double> dEdx_val_previousTool;
+      ShowerEleHolder.GetElement(fShowerdEdxOutputLabel, dEdx_val_previousTool);
+      if (fVerbose > 2) {
+        std::cout << "Result from previous dEdx tool..." << std::endl;
+        for (unsigned int plane = 0; plane < dEdx_val_previousTool.size(); plane++) {
+          std::cout << "Plane: " << plane << " with dEdx: " << dEdx_val_previousTool[plane] << std::endl;
+        }
+      } 
+
+      std::vector<double> dEdx_val_overriddenPerPlane(dEdx_val);
+
+      for (unsigned int plane = 0; plane < dEdx_val.size(); plane++) {
+        //If the current tool fails, just retain plane-by-plane the result from the previous tool
+        if (dEdx_val[plane] < 0.) {
+          dEdx_val_overriddenPerPlane[plane] = dEdx_val_previousTool[plane];
+          if (fVerbose > 2) {
+            std::cout << "This tool failed in plane " << plane << " and I am keeping the previous value" << std::endl;
+            std::cout << "Current value: " << dEdx_val[plane] << std::endl;
+            std::cout << "Chosen value:  " << dEdx_val_overriddenPerPlane[plane] << std::endl;
+          }
+        }
+        else {
+          dEdx_val_overriddenPerPlane[plane] = dEdx_val[plane];
+        }
+      }
+
+      //Need to sort out errors sensibly.
+      ShowerEleHolder.SetElement(dEdx_val_overriddenPerPlane, dEdx_valErr, fShowerdEdxOutputLabel);
+      ShowerEleHolder.SetElement(best_plane, fShowerBestPlaneOutputLabel);
+      ShowerEleHolder.SetElement(dEdx_vec_cut, fShowerdEdxVecOutputLabel);
+      return 0;
     }
 
     //Need to sort out errors sensibly.

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/pandorashowertools.fcl
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/pandorashowertools.fcl
@@ -289,7 +289,7 @@ showertrajpointdedx:{
     SCECorrectEField:     false
     SCEInputCorrected:    false
     SumHitSnippets:       false
-    OverrideByPlane:      false
+    ResultsOverrideMode:  0
     # PFParticleLabel: "pandora"
     ShowerStartPositionInputLabel: "ShowerStartPosition"
     InitialTrackSpacePointsInputLabel: "InitialTrackSpacePoints"

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/pandorashowertools.fcl
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/pandorashowertools.fcl
@@ -288,7 +288,8 @@ showertrajpointdedx:{
     SCECorrectPitch:      false
     SCECorrectEField:     false
     SCEInputCorrected:    false
-    SumHitSnippets: false
+    SumHitSnippets:       false
+    OverrideByPlane:      false
     # PFParticleLabel: "pandora"
     ShowerStartPositionInputLabel: "ShowerStartPosition"
     InitialTrackSpacePointsInputLabel: "InitialTrackSpacePoints"


### PR DESCRIPTION
This PR (based off of `larpandora v09_21_19`) adds an option to change the overriding logic in the trajectory-based dE/dx tool (`ShowerTrajPointdEdx`). SBN experiments use the Modular Shower Creation interface, and commonly run the uni-directional dE/dx tool (`ShowerUnidirectiondEdx`) first, and then the trajectory-based tool, which overrides the previous result only if it fails on all planes (Induction-1, Induction-2, Collection). Optionally through the `OverrideByPlane` FHiCL parameter, this PR adds the possibility to override the trajectory-based result on a plane-by-plane basis.
In ICARUS, we have seen a 10-15% improvement in the dE/dx reconstruction efficiency in each plane with the plane-by-plane overriding.

Tagging @absolution1 and @AndyChappell: thanks!