### PR TITLE
Add guard to trajectory-based dE/dx tool overriding infrastructure

### DIFF
--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrajPointdEdx_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrajPointdEdx_tool.cc
@@ -401,13 +401,25 @@ namespace ShowerRecoTools {
 
     //Get results from the same label, if set by a previous tool of the same type
     std::vector<double> dEdx_val_previousTool;
-    ShowerEleHolder.GetElement(fShowerdEdxOutputLabel, dEdx_val_previousTool);
-    if (fVerbose > 2) {
-      std::cout << "Result from previous dEdx tool..." << std::endl;
-      for (unsigned int plane = 0; plane < dEdx_val_previousTool.size(); plane++) {
-        std::cout << "Plane: " << plane << " with dEdx: " << dEdx_val_previousTool[plane]
-                  << std::endl;
-      }
+
+    if (ShowerEleHolder.CheckElement(fShowerdEdxOutputLabel)) {
+      ShowerEleHolder.GetElement(fShowerdEdxOutputLabel, dEdx_val_previousTool);
+      if (fVerbose > 2) {
+        std::cout << "Result from previous dEdx tool..." << std::endl;
+        for (unsigned int plane = 0; plane < dEdx_val_previousTool.size(); plane++) {
+          std::cout << "Plane: " << plane << " with dEdx: " << dEdx_val_previousTool[plane] << std::endl;
+        }
+      } 
+    } else {
+      //If the previous tool didn't run at all, just use this one
+      if (fVerbose > 1) {
+        std::cout << "No previous tool to be overridden" << std::endl;
+      } 
+      ShowerEleHolder.SetElement(dEdx_val, dEdx_valErr, fShowerdEdxOutputLabel);
+      ShowerEleHolder.SetElement(best_plane, fShowerBestPlaneOutputLabel);
+      ShowerEleHolder.SetElement(dEdx_vec_cut, fShowerdEdxVecOutputLabel);
+
+      return 0;
     }
 
     //Choose how to override results from the previous tool


### PR DESCRIPTION
This PR (based off of `larpandora v09_21_19`) adds a guard to the trajectory-based dE/dx tool (`ShowerTrajPointdEdx`) overriding infrastructure (PR #32), where it was assumed that another tool would write on the same label beforehand, 
causing the SBND CI to fail.

Tagging @absolution1 and @AndyChappell: thanks!