### PR TITLE
Adding EDepSimModule label

### DIFF
--- a/larpandora/LArPandoraInterface/LArPandora.cxx
+++ b/larpandora/LArPandoraInterface/LArPandora.cxx
@@ -56,7 +56,7 @@ namespace lar_pandora {
     , m_generatorModuleLabel(pset.get<std::string>("GeneratorModuleLabel", ""))
     , m_geantModuleLabel(pset.get<std::string>("GeantModuleLabel", "largeant"))
     , m_simChannelModuleLabel(pset.get<std::string>("SimChannelModuleLabel", m_geantModuleLabel))
-    , m_eDepSimModuleLabel(pset.get<std::string>("EDepSimModuleLabel", ""))
+    , m_eDepSimModuleLabel(pset.get<std::string>("EDepSimModuleLabel", "IonAndScint"))
     , m_hitfinderModuleLabel(pset.get<std::string>("HitFinderModuleLabel"))
     , m_backtrackerModuleLabel(pset.get<std::string>("BackTrackerModuleLabel", ""))
     , m_allOutcomesInstanceLabel(pset.get<std::string>("AllOutcomesInstanceLabel", "allOutcomes"))


### PR DESCRIPTION
Setting IonAndScint as the default EDepSimModule label in Pandora.cxx. The EDepSims are used to calculate the visible energy member variable of the Pandora MCParticle.

Dom assures me that the 'IonAndScint' label will work for any experiment using refactored larg4. If this label is not correct, larsoft will complain that the data products cannot be found and will crash. This label would then have to be set in the experiment's pandoramodules.fcl.